### PR TITLE
Prevent oscillations of the charge percentage (plus save a few bytes!)

### DIFF
--- a/helper/battery.c
+++ b/helper/battery.c
@@ -97,6 +97,20 @@ unsigned int BATTERY_VoltsToPercent(const unsigned int voltage_10mV)
 	return 0;
 }
 
+unsigned int BATTERY_PercentMonotonic(unsigned int percent)
+{
+	static uint8_t prev = 101;
+
+	if (gChargingWithTypeC) {
+		if (percent > prev)
+			prev = percent;
+	} else {
+		if (percent < prev)
+			prev = percent;
+	}
+	return prev;
+}
+
 void BATTERY_GetReadings(const bool bDisplayBatteryLevel)
 {
 	const uint8_t  PreviousBatteryLevel = gBatteryDisplayLevel;
@@ -111,7 +125,7 @@ void BATTERY_GetReadings(const bool bDisplayBatteryLevel)
 	else {
 		gBatteryDisplayLevel = 1;
 		const uint8_t levels[] = {5,17,41,65,88};
-		uint8_t perc = BATTERY_VoltsToPercent(gBatteryVoltageAverage);
+		uint8_t perc = BATTERY_PercentMonotonic(BATTERY_VoltsToPercent(gBatteryVoltageAverage));
 		for(uint8_t i = 6; i >= 1; i--){
 			if (perc > levels[i-2]) {
 				gBatteryDisplayLevel = i;


### PR DESCRIPTION
Hello,

Here are two changes related to the display of the battery state of charge. The first one saves 40 byte in the binary, the other one fixes a minor issue with the SoC display as discussed on YouTube.

Be aware that this is compile-tested and simulation-tested only, as I don't have a transceiver to run this on. FYI below is the output of a simple test program I ran on my PC to make sure the new `BATTERY_VoltsToPercent()` still shows (mostly) the same values as the old one.

```
BATTERY_TYPE_1600_MAH
  V  old  new
600    0    0
610    0    0
620    0    0
630    0    0
640    1    0
650    2    1
660    2    1
670    3    2
680    3    3
690    4    3
700    5    4
710    5    4
720    6    5
730    6    6
740   12   13
750   19   19
760   25   25
770   38   38
780   51   51
790   65   65
800   78   78
810   91   91
820   98   98
830  100  100
840  100  100
850  100  100
860  100  100
870  100  100
880  100  100
890  100  100
900  100  100

BATTERY_TYPE_2200_MAH
  V  old  new
600    0    0
610    0    0
620    0    0
630    0    0
640    1    1
650    2    2
660    3    3
670    4    4
680    5    5
690   10   10
700   17   16
710   25   24
720   37   36
730   49   48
740   60   60
750   65   64
760   70   69
770   74   74
780   79   79
790   84   84
800   89   88
810   93   93
820   97   97
830  100  100
840  100  100
850  100  100
860  100  100
870  100  100
880  100  100
890  100  100
900  100  100
```

[batt.c.txt](https://github.com/user-attachments/files/15874667/batt.c.txt)