### PR TITLE
Update spectrum.c: save a few bytes

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -66,7 +66,7 @@ static uint16_t blacklistFreqs[15];
 static uint8_t blacklistFreqsIdx;
 #endif
 
-const char *bwOptions[] = {"  25k", "12.5k", "6.25k"};
+const char *bwOptions[] = {"25", "12.5", "6.25"};
 const uint8_t modulationTypeTuneSteps[] = {100, 50, 10};
 const uint8_t modTypeReg47Values[] = {1, 7, 5};
 
@@ -778,7 +778,7 @@ static void DrawF(uint32_t f) {
 
   sprintf(String, "%3s", gModulationStr[settings.modulationType]);
   GUI_DisplaySmallest(String, 116, 1, false, true);
-  sprintf(String, "%s", bwOptions[settings.listenBw]);
+  sprintf(String, "%4sk", bwOptions[settings.listenBw]);
   GUI_DisplaySmallest(String, 108, 7, false, true);
 
 #ifndef ENABLE_FMRADIO


### PR DESCRIPTION
Also, changing `static uint16_t blacklistFreqs[15];` to `static uint16_t blacklistFreqs[16];` may save a few more bytes... I don't know why.