### PR TITLE
spectrum: don't scan last frequency (out of graph range)

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -1196,7 +1196,7 @@ static void NextScanStep() {
 static void UpdateScan() {
   Scan();
 
-  if (scanInfo.i < scanInfo.measurementsCount) {
+  if (scanInfo.i < scanInfo.measurementsCount - 1) {
     NextScanStep();
     return;
   }


### PR DESCRIPTION
Not sure if this is the correct place, but nothing broke so far... fixes second part of https://github.com/armel/uv-k5-firmware-custom/issues/151