### PR TITLE
Revert "spectrum: don't check blacklistFreqs if unset"

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -671,10 +671,9 @@ static void Blacklist() {
 #ifdef ENABLE_SCAN_RANGES
 static bool IsBlacklisted(uint16_t idx)
 {
-  if(blacklistedFreqs[0]) // cheaper than checking blacklistFreqsIdx
-    for(uint8_t i = 0; i < ARRAY_SIZE(blacklistFreqs); i++)
-      if(blacklistFreqs[i] == idx)
-        return true;
+  for(uint8_t i = 0; i < ARRAY_SIZE(blacklistFreqs); i++)
+    if(blacklistFreqs[i] == idx)
+      return true;
   return false;
 }
 #endif


### PR DESCRIPTION
Reverts armel/uv-k5-firmware-custom#152

app/spectrum.c: In function 'IsBlacklisted':
app/spectrum.c:674:6: error: 'blacklistedFreqs' undeclared (first use in this function); did you mean 'blacklistFreqs'?
  674 |   if(blacklistedFreqs[0]) // cheaper than checking blacklistFreqsIdx
      |      ^~~~~~~~~~~~~~~~
      |      blacklistFreqs
app/spectrum.c:674:6: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:484: app/spectrum.o] Error 1