### PR TITLE
Fix some issues (#173) with memory channel input

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1444,7 +1444,7 @@ void cancelUserInputModes(void)
 		gWasFKeyPressed     = false;
 		gInputBoxIndex      = 0;
 		gKeyInputCountdown  = 0;
-		gBeepToPlay         = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+		gBeepToPlay         = BEEP_NONE;
 		gUpdateStatus       = true;
 		gUpdateDisplay      = true;
 	}
@@ -1473,26 +1473,6 @@ void APP_TimeSlice500ms(void)
 			}
 
 			cancelUserInputModes();
-
-			if (gBeepToPlay != BEEP_NONE)
-			{
-				AUDIO_PlayBeep(gBeepToPlay);
-				gBeepToPlay = BEEP_NONE;
-			}
-		}
-		else
-		{
-			if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
-				switch (gInputBoxIndex)
-				{
-					case 1:
-						channelMove(gInputBox[0] - 1, false);
-						break;
-					case 2:
-						channelMove(((gInputBox[0] * 10) + gInputBox[1]) - 1, false);
-						break;
-				}
-			}
 		}
 	}
 

--- a/app/main.c
+++ b/app/main.c
@@ -348,6 +348,29 @@ void channelMove(uint16_t Channel, bool End)
 	return;
 }
 
+void channelMoveSwitch(void) {
+	if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
+		switch (gInputBoxIndex)
+		{
+			case 1:
+				if (gInputBox[0] != 0) {
+					channelMove(gInputBox[0] - 1, false);
+				}
+
+				break;
+			case 2:
+				if (!((gInputBox[0] == 0) && (gInputBox[1] == 0))) {
+					channelMove(((gInputBox[0] * 10) + gInputBox[1]) - 1, false);
+				}
+
+				break;
+			case 3:
+				channelMove(((gInputBox[0] * 100) + (gInputBox[1] * 10) + gInputBox[2]) - 1, true);
+				break;
+		}
+	}
+}
+
 static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 {
 	if (bKeyHeld) { // key held down
@@ -402,23 +425,24 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		}
 
 		const uint8_t Vfo = gEeprom.TX_VFO;
-		gKeyInputCountdown = key_input_timeout_500ms;
 		INPUTBOX_Append(Key);
+		gKeyInputCountdown = key_input_timeout_500ms;
+
+		if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
+			channelMoveSwitch();
+		}
+
 		gRequestDisplayScreen = DISPLAY_MAIN;
 
 		if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
 
 			gKeyInputCountdown = (key_input_timeout_500ms / 5); // short time...
 
-			if (gInputBoxIndex != 3) {
-				#ifdef ENABLE_VOICE
-					gAnotherVoiceID   = (VOICE_ID_t)Key;
-				#endif
-				gRequestDisplayScreen = DISPLAY_MAIN;
-				return;
-			}
-
-			channelMove(((gInputBox[0] * 100) + (gInputBox[1] * 10) + gInputBox[2]) - 1, true);
+			#ifdef ENABLE_VOICE
+				gAnotherVoiceID   = (VOICE_ID_t)Key;
+			#endif
+			
+			return;
 		}
 
 //		#ifdef ENABLE_NOAA
@@ -546,11 +570,14 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 #endif
 		{
 			if (gScanStateDir == SCAN_OFF) {
-				if (gInputBoxIndex == 0)
+				if (gInputBoxIndex == 0) {
 					return;
+				}
 				gInputBox[--gInputBoxIndex] = 10;
 
-				gKeyInputCountdown = key_input_timeout_500ms;
+				gKeyInputCountdown = key_input_timeout_500ms / 5;
+
+				channelMoveSwitch();
 
 #ifdef ENABLE_VOICE
 				if (gInputBoxIndex == 0)


### PR DESCRIPTION
Having time off I decided to try and fix the bug problem I posted. I think the result was worth the sacrifice.

What I did:
- The channel changes immediately when a digit is entered
    - if one or two zeros are entered at the beginning, it will continue to wait for the last one
- deleting a digit will change the channel to the previous one (e.g. from 29 to 2)

The bug has been fixed. Now changing the channel during reception will actually change the channel without receiving the previous one.