### PR TITLE
Double beep for non-existent channel, refactoring channel change

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1444,7 +1444,7 @@ void cancelUserInputModes(void)
 		gWasFKeyPressed     = false;
 		gInputBoxIndex      = 0;
 		gKeyInputCountdown  = 0;
-		gBeepToPlay         = BEEP_NONE;
+		gBeepToPlay         = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
 		gUpdateStatus       = true;
 		gUpdateDisplay      = true;
 	}
@@ -1469,6 +1469,12 @@ void APP_TimeSlice500ms(void)
 
 			if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE) && (gInputBoxIndex == 1 || gInputBoxIndex == 2))
 			{
+				channelMoveSwitch();
+
+				if (gBeepToPlay == BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL) {
+					AUDIO_PlayBeep(gBeepToPlay);
+				}
+
 				SETTINGS_SaveVfoIndices();
 			}
 

--- a/app/app.c
+++ b/app/app.c
@@ -1444,7 +1444,7 @@ void cancelUserInputModes(void)
 		gWasFKeyPressed     = false;
 		gInputBoxIndex      = 0;
 		gKeyInputCountdown  = 0;
-		gBeepToPlay         = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+		gBeepToPlay         = BEEP_NONE;
 		gUpdateStatus       = true;
 		gUpdateDisplay      = true;
 	}
@@ -1473,26 +1473,6 @@ void APP_TimeSlice500ms(void)
 			}
 
 			cancelUserInputModes();
-
-			if (gBeepToPlay != BEEP_NONE)
-			{
-				AUDIO_PlayBeep(gBeepToPlay);
-				gBeepToPlay = BEEP_NONE;
-			}
-		}
-		else
-		{
-			if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
-				switch (gInputBoxIndex)
-				{
-					case 1:
-						channelMove(gInputBox[0] - 1, false);
-						break;
-					case 2:
-						channelMove(((gInputBox[0] * 10) + gInputBox[1]) - 1, false);
-						break;
-				}
-			}
 		}
 	}
 

--- a/app/main.c
+++ b/app/main.c
@@ -787,9 +787,6 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 	uint8_t Channel = gEeprom.ScreenChannel[gEeprom.TX_VFO];
 
 	if (bKeyHeld || !bKeyPressed) { // key held or released
-		if (gInputBoxIndex > 0)
-			return; // leave if input box active
-
 		if (!bKeyPressed) {
 			if (!bKeyHeld || IS_FREQ_CHANNEL(Channel))
 				return;
@@ -803,8 +800,8 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 	}
 	else { // short pressed
 		if (gInputBoxIndex > 0) {
-			gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
-			return;
+			gInputBoxIndex = 0;
+			gKeyInputCountdown = 1;
 		}
 		gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 	}

--- a/app/main.c
+++ b/app/main.c
@@ -348,6 +348,29 @@ void channelMove(uint16_t Channel, bool End)
 	return;
 }
 
+void channelMoveSwitch(void) {
+	if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
+		switch (gInputBoxIndex)
+		{
+			case 1:
+				if (gInputBox[0] != 0) {
+					channelMove(gInputBox[0] - 1, false);
+				}
+
+				break;
+			case 2:
+				if (!((gInputBox[0] == 0) && (gInputBox[1] == 0))) {
+					channelMove(((gInputBox[0] * 10) + gInputBox[1]) - 1, false);
+				}
+
+				break;
+			case 3:
+				channelMove(((gInputBox[0] * 100) + (gInputBox[1] * 10) + gInputBox[2]) - 1, true);
+				break;
+		}
+	}
+}
+
 static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 {
 	if (bKeyHeld) { // key held down
@@ -402,23 +425,24 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		}
 
 		const uint8_t Vfo = gEeprom.TX_VFO;
-		gKeyInputCountdown = key_input_timeout_500ms;
 		INPUTBOX_Append(Key);
+		gKeyInputCountdown = key_input_timeout_500ms;
+
+		if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
+			channelMoveSwitch();
+		}
+
 		gRequestDisplayScreen = DISPLAY_MAIN;
 
 		if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) { // user is entering channel number
 
 			gKeyInputCountdown = (key_input_timeout_500ms / 5); // short time...
 
-			if (gInputBoxIndex != 3) {
-				#ifdef ENABLE_VOICE
-					gAnotherVoiceID   = (VOICE_ID_t)Key;
-				#endif
-				gRequestDisplayScreen = DISPLAY_MAIN;
-				return;
-			}
-
-			channelMove(((gInputBox[0] * 100) + (gInputBox[1] * 10) + gInputBox[2]) - 1, true);
+			#ifdef ENABLE_VOICE
+				gAnotherVoiceID   = (VOICE_ID_t)Key;
+			#endif
+			
+			return;
 		}
 
 //		#ifdef ENABLE_NOAA
@@ -546,11 +570,14 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 #endif
 		{
 			if (gScanStateDir == SCAN_OFF) {
-				if (gInputBoxIndex == 0)
+				if (gInputBoxIndex == 0) {
 					return;
+				}
 				gInputBox[--gInputBoxIndex] = 10;
 
-				gKeyInputCountdown = key_input_timeout_500ms;
+				gKeyInputCountdown = key_input_timeout_500ms / 5;
+
+				channelMoveSwitch();
 
 #ifdef ENABLE_VOICE
 				if (gInputBoxIndex == 0)

--- a/app/main.h
+++ b/app/main.h
@@ -20,7 +20,7 @@
 #include "driver/keyboard.h"
 
 void MAIN_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld);
-void channelMove(uint16_t Channel, bool End);
+void channelMoveSwitch(void);
 
 #endif
 


### PR DESCRIPTION
During use, I noticed that the existence of the channel is checked every time a digit is entered. For example, suppose we have channel 35 stored, but channel 3 is empty. Entering the digit 3 will trigger a beep indicating that there is no channel 3 even though our intention is not to go to channel 3. The timeout is still in progress, so pressing 5 will go to channel 35 which exists. I have made the beep appear after the timeout has stopped (for one-digit and two-digit numbers). The problem does not appear with three-digit numbers, because there is no timeout there.

I also managed to save 8 bytes, but it works the same as before.

Modified code: 6820b0a0b4c2ace75c4272eaef5ac488a8e71d69