### PR TITLE
NOAA mode fixes

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -210,9 +210,9 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
                     gEeprom.ScreenChannel[Vfo] = gEeprom.NoaaChannel[gEeprom.TX_VFO];
                 }
                 else {
-                    gEeprom.ScreenChannel[Vfo] = gEeprom.FreqChannel[gEeprom.TX_VFO];
+                    gEeprom.ScreenChannel[Vfo] = gEeprom.MrChannel[gEeprom.TX_VFO];
 #ifdef ENABLE_VOICE
-                        gAnotherVoiceID = VOICE_ID_FREQUENCY_MODE;
+                        gAnotherVoiceID = VOICE_ID_CHANNEL_MODE;
 #endif
                 }
                 gRequestSaveVFO   = true;

--- a/bitmaps.c
+++ b/bitmaps.c
@@ -298,6 +298,23 @@ const uint8_t BITMAP_PowerUser[3] =
     0b00001000,
 };
 
+#ifdef ENABLE_NOAA
+const uint8_t BITMAP_NOAA[12] =
+{	// "WX"
+    0b00000000,
+    0b01111111,
+    0b00100000,
+    0b00011000,
+    0b00100000,
+    0b01111111,
+    0b00000000,
+    0b01100011,
+    0b00010100,
+    0b00001000,
+    0b00010100,
+    0b01100011
+};
+#endif
 
 #ifndef ENABLE_CUSTOM_MENU_LAYOUT
 const uint8_t BITMAP_CurrentIndicator[8] = {

--- a/bitmaps.h
+++ b/bitmaps.h
@@ -41,6 +41,8 @@ extern const uint8_t BITMAP_ScanListE[7];
 extern const uint8_t BITMAP_PowerUser[3];
 extern const uint8_t BITMAP_compand[6];
 
+extern const uint8_t BITMAP_NOAA[12];
+
 #ifndef ENABLE_CUSTOM_MENU_LAYOUT
     extern const uint8_t BITMAP_CurrentIndicator[8];
 #endif

--- a/functions.c
+++ b/functions.c
@@ -79,7 +79,7 @@ void FUNCTION_Init(void)
     gNOAACountdown_10ms = 0;
 
     if (IS_NOAA_CHANNEL(gRxVfo->CHANNEL_SAVE)) {
-        gCurrentCodeType = CODE_TYPE_CONTINUOUS_TONE;
+        gCurrentCodeType = CODE_TYPE_OFF;
     }
 #endif
 


### PR DESCRIPTION
Since with Scan Ranges on, you can only get to NOAA from MR mode, enable exiting NOAA mode back to MR mode.

I also could not enable NOAA mode without errors, so I restored the BITMAP_NOAA array from the last state when it was removed, plus wrapped it in `#ifdef ENABLE_NOAA`.

Also set the tone mode to OFF, since NOAA channels never have tones and I couldn't hear them without going to Monitor mode or setting Squelch to 0, which is annoying and unusual.