### PR TITLE
rework irq bit flag testing, saves 16bytes (RAF)

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -644,39 +644,33 @@ static void DualwatchAlternate(void)
     #endif
 }
 
+///UNUSED	#define B0			(1<<0)
+#define FSKRX_SYNC				(1<<1)
+#define SQL_LOST				(1<<2)
+#define SQL_FOUND				(1<<3)
+#define VOX_LOST				(1<<4)
+#define VOX_FOUND				(1<<5)
+#define CTCSS_LOST				(1<<6)
+#define CTCSS_FOUND				(1<<7)
+#define CDCSS_LOST				(1<<8)
+#define CDCSS_FOUND				(1<<9)
+#define CSSTAIL_FOUND				(1<<10)
+#define DMTF5_TONE_FOUND			(1<<11)
+#define FSKFIFO_ALMOST_FULL			(1<<12) // pls define almost ?
+///UNUSED_ATM	#define FSK_RX_END		(1<<13)
+///UNUSED_ATM	#define FXKFIFO_ALMOST_EMPTY	(1<<14)
+///UNUSED_ATM	#define FSK_TX_FINISHED		(1<<15)
+
 static void CheckRadioInterrupts(void)
 {
     if (SCANNER_IsScanning())
         return;
 
-    while (BK4819_ReadRegister(BK4819_REG_0C) & 1u) { // BK chip interrupt request
-        // clear interrupts
-        BK4819_WriteRegister(BK4819_REG_02, 0);
-        // fetch interrupt status bits
-
-        union {
-            struct {
-                uint16_t __UNUSED : 1;
-                uint16_t fskRxSync : 1;
-                uint16_t sqlLost : 1;
-                uint16_t sqlFound : 1;
-                uint16_t voxLost : 1;
-                uint16_t voxFound : 1;
-                uint16_t ctcssLost : 1;
-                uint16_t ctcssFound : 1;
-                uint16_t cdcssLost : 1;
-                uint16_t cdcssFound : 1;
-                uint16_t cssTailFound : 1;
-                uint16_t dtmf5ToneFound : 1;
-                uint16_t fskFifoAlmostFull : 1;
-                uint16_t fskRxFinied : 1;
-                uint16_t fskFifoAlmostEmpty : 1;
-                uint16_t fskTxFinied : 1;
-            };
-            uint16_t __raw;
-        } interrupts;
-
-        interrupts.__raw = BK4819_ReadRegister(BK4819_REG_02);
+	while (BK4819_ReadRegister(BK4819_REG_0C) & 1u) { // BK chip interrupt request
+		// clear interrupts
+		BK4819_WriteRegister(BK4819_REG_02, 0);
+		// fetch interrupt status bits
+		uint16_t reg = BK4819_ReadRegister(BK4819_REG_02);
 
         // 0 = no phase shift
         // 1 = 120deg phase shift
@@ -686,21 +680,21 @@ static void CheckRadioInterrupts(void)
 //      if (ctcss_shift > 0)
 //          g_CTCSS_Lost = true;
 
-        if (interrupts.dtmf5ToneFound) {    
-            const char c = DTMF_GetCharacter(BK4819_GetDTMF_5TONE_Code()); // save the RX'ed DTMF character
-            if (c != 0xff) {
-                if (gCurrentFunction != FUNCTION_TRANSMIT) {
-                    if (gSetting_live_DTMF_decoder) {
-                        size_t len = strlen(gDTMF_RX_live);
-                        if (len >= sizeof(gDTMF_RX_live) - 1) { // make room
-                            memmove(&gDTMF_RX_live[0], &gDTMF_RX_live[1], sizeof(gDTMF_RX_live) - 1);
-                            len--;
-                        }
-                        gDTMF_RX_live[len++]  = c;
-                        gDTMF_RX_live[len]    = 0;
-                        gDTMF_RX_live_timeout = DTMF_RX_live_timeout_500ms;  // time till we delete it
-                        gUpdateDisplay        = true;
-                    }
+		if (reg & DMTF5_TONE_FOUND) {
+			const char c = DTMF_GetCharacter(BK4819_GetDTMF_5TONE_Code()); // save the RX'ed DTMF character
+			if (c != 0xff) {
+				if (gCurrentFunction != FUNCTION_TRANSMIT) {
+					if (gSetting_live_DTMF_decoder) {
+						size_t len = strlen(gDTMF_RX_live);
+						if (len >= sizeof(gDTMF_RX_live) - 1) { // make room
+							memmove(&gDTMF_RX_live[0], &gDTMF_RX_live[1], sizeof(gDTMF_RX_live) - 1);
+							len--;
+						}
+						gDTMF_RX_live[len++]  = c;
+						gDTMF_RX_live[len]    = 0;
+						gDTMF_RX_live_timeout = DTMF_RX_live_timeout_500ms;  // time till we delete it
+						gUpdateDisplay        = true;
+					}
 
 #ifdef ENABLE_DTMF_CALLING
                     if (gRxVfo->DTMF_DECODING_ENABLE || gSetting_KILLED) {
@@ -721,27 +715,27 @@ static void CheckRadioInterrupts(void)
             }
         }
 
-        if (interrupts.cssTailFound)
-            g_CxCSS_TAIL_Found = true;
+		if (reg & CSSTAIL_FOUND)
+			g_CxCSS_TAIL_Found = true;
 
-        if (interrupts.cdcssLost) {
-            g_CDCSS_Lost = true;
-            gCDCSSCodeType = BK4819_GetCDCSSCodeType();
-        }
+		if (reg & CDCSS_LOST) {
+			g_CDCSS_Lost = true;
+			gCDCSSCodeType = BK4819_GetCDCSSCodeType();
+		}
 
-        if (interrupts.cdcssFound)
-            g_CDCSS_Lost = false;
+		if (reg & CDCSS_FOUND)
+			g_CDCSS_Lost = false;
 
-        if (interrupts.ctcssLost)
-            g_CTCSS_Lost = true;
+		if (reg & CTCSS_LOST)
+			g_CTCSS_Lost = true;
 
-        if (interrupts.ctcssFound)
-            g_CTCSS_Lost = false;
+		if (reg & CTCSS_FOUND)
+			g_CTCSS_Lost = false;
 
 #ifdef ENABLE_VOX
-        if (interrupts.voxLost) {
-            g_VOX_Lost         = true;
-            gVoxPauseCountdown = 10;
+		if (reg & VOX_LOST) {
+			g_VOX_Lost         = true;
+			gVoxPauseCountdown = 10;
 
             if (gEeprom.VOX_SWITCH) {
                 if (gCurrentFunction == FUNCTION_POWER_SAVE && !gRxIdleMode) {
@@ -760,34 +754,34 @@ static void CheckRadioInterrupts(void)
             }
         }
 
-        if (interrupts.voxFound) {
-            g_VOX_Lost         = false;
-            gVoxPauseCountdown = 0;
-        }
+		if (reg & VOX_FOUND) {
+			g_VOX_Lost         = false;
+			gVoxPauseCountdown = 0;
+		}
 #endif
 
-        if (interrupts.sqlLost) {
-            g_SquelchLost = true;
-            BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, true);
-            #ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER
-                gRxTimerCountdown_500ms = 7200;
-            #endif
-        }
+		if (reg & SQL_LOST) {
+			g_SquelchLost = true;
+			BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, true);
+			#ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER
+				gRxTimerCountdown_500ms = 7200;
+			#endif
+		}
 
-        if (interrupts.sqlFound) {
-            g_SquelchLost = false;
-            BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, false);
-        }
+		if (reg & SQL_FOUND) {
+			g_SquelchLost = false;
+			BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, false);
+		}
 
 #ifdef ENABLE_AIRCOPY
-        if (interrupts.fskFifoAlmostFull &&
-            gScreenToDisplay == DISPLAY_AIRCOPY &&
-            gAircopyState == AIRCOPY_TRANSFER &&
-            gAirCopyIsSendMode == 0)
-        {
-            for (unsigned int i = 0; i < 4; i++) {
-                g_FSK_Buffer[gFSKWriteIndex++] = BK4819_ReadRegister(BK4819_REG_5F);
-            }
+		if ((reg & FSKFIFO_ALMOST_FULL) &&
+			gScreenToDisplay == DISPLAY_AIRCOPY &&
+			gAircopyState == AIRCOPY_TRANSFER &&
+			gAirCopyIsSendMode == 0)
+		{
+			for (unsigned int i = 0; i < 4; i++) {
+				g_FSK_Buffer[gFSKWriteIndex++] = BK4819_ReadRegister(BK4819_REG_5F);
+			}
 
             AIRCOPY_StorePacket();
         }


### PR DESCRIPTION
This patch applies cleanly to armel v3.3 but cannot go further of this commit

```
e64a615 - Check tab only...
74862d1 - Check tab only... <--- this one
```

Compilation with patch saves between 16 and 20 bytesi (alignment).

**BEFORE**:

```
bin/ld: f4hwn.voxless section `.data' will not fit in region `FLASH'
bin/ld: region `FLASH' overflowed by 4 bytes
collect2: error: ld returned 1 exit status

   text    data     bss     dec     hex filename
  58996      52    3304   62352    f390 f4hwn.bandscope
   text    data     bss     dec     hex filename
  57216      20    2944   60180    eb14 f4hwn.broadcast
```

**AFTER**:

```
   text    data     bss     dec     hex filename
  61368      52    3356   64776    fd08 f4hwn.voxless
   text    data     bss     dec     hex filename
  58980      52    3304   62336    f380 f4hwn.bandscope (-16)
   text    data     bss     dec     hex filename
  57196      20    2944   60160    eb00 f4hwn.broadcast (-20)
```

Dummy integration taking the whole patch as granted as per solving the conflict: bare replacement of the code.

Signed-off-by: Roberto A. Foglietta <roberto.foglietta@gmail.com>

Patch author:

Signed-off-by: Robert Woerle <rwoerl@mibtec.de>
