### PR TITLE
fix #322: scale bandscope for any number of samples

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -871,8 +871,8 @@ uint8_t Rssi2Y(uint16_t rssi)
     static void DrawSpectrum()
     {
         uint16_t steps = GetStepsCount();
-        uint16_t bars = (steps > 128) ? 128 : steps;
-        uint16_t shift_graph = 64 / steps + 1; // to center bar on freq marker
+        uint8_t bars = (steps > 128) ? 128 : steps;
+        uint8_t shift_graph = 64 / steps + 1; // to center bar on freq marker
         uint8_t ox = 0;
         for (uint8_t i = 0; i < 128; ++i)
         {

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -870,13 +870,14 @@ uint8_t Rssi2Y(uint16_t rssi)
 #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
     static void DrawSpectrum()
     {
+        uint16_t steps = GetStepsCount();
         uint8_t ox = 0;
         for (uint8_t i = 0; i < 128; ++i)
         {
             uint16_t rssi = rssiHistory[i >> settings.stepsCount];
             if (rssi != RSSI_MAX_VALUE)
             {
-                uint8_t x = i * 128 / GetStepsCount();
+                uint8_t x = i * 128 / ((steps > 128) ? 128 : steps) + 1;
                 for (uint8_t xx = ox; xx < x; xx++)
                 {
                     DrawVLine(Rssi2Y(rssi), DrawingEndY, xx, true);

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -871,8 +871,11 @@ uint8_t Rssi2Y(uint16_t rssi)
     static void DrawSpectrum()
     {
         uint16_t steps = GetStepsCount();
+        // for larger numbers of samples, max at 128 to correctly draw
         uint8_t bars = (steps > 128) ? 128 : steps;
-        uint8_t shift_graph = 64 / steps + 1; // to center bar on freq marker
+        // to center bar on freq marker
+        uint8_t shift_graph = 64 / steps + 1;
+
         uint8_t ox = 0;
         for (uint8_t i = 0; i < 128; ++i)
         {

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -871,13 +871,15 @@ uint8_t Rssi2Y(uint16_t rssi)
     static void DrawSpectrum()
     {
         uint16_t steps = GetStepsCount();
+        uint16_t scale = ((steps > 128) ? 128 : steps);
+        uint16_t shift = 64 / steps + 1;
         uint8_t ox = 0;
         for (uint8_t i = 0; i < 128; ++i)
         {
             uint16_t rssi = rssiHistory[i >> settings.stepsCount];
             if (rssi != RSSI_MAX_VALUE)
             {
-                uint8_t x = i * 128 / ((steps > 128) ? 128 : steps) + 1;
+              uint8_t x = i * 128 / scale + shift;
                 for (uint8_t xx = ox; xx < x; xx++)
                 {
                     DrawVLine(Rssi2Y(rssi), DrawingEndY, xx, true);

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -871,9 +871,9 @@ uint8_t Rssi2Y(uint16_t rssi)
     static void DrawSpectrum()
     {
         uint16_t steps = GetStepsCount();
-        // for larger numbers of samples, max at 128 to correctly draw
+        // max bars at 128 to correctly draw larger numbers of samples
         uint8_t bars = (steps > 128) ? 128 : steps;
-        // to center bar on freq marker
+        // shift to center bar on freq marker
         uint8_t shift_graph = 64 / steps + 1;
 
         uint8_t ox = 0;

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -871,7 +871,7 @@ uint8_t Rssi2Y(uint16_t rssi)
     static void DrawSpectrum()
     {
         uint16_t steps = GetStepsCount();
-        uint16_t scale = ((steps > 128) ? 128 : steps);
+        uint16_t scale = (steps > 128) ? 128 : steps;
         uint16_t shift = 64 / steps + 1;
         uint8_t ox = 0;
         for (uint8_t i = 0; i < 128; ++i)

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -879,7 +879,7 @@ uint8_t Rssi2Y(uint16_t rssi)
             uint16_t rssi = rssiHistory[i >> settings.stepsCount];
             if (rssi != RSSI_MAX_VALUE)
             {
-              uint8_t x = i * 128 / scale + shift;
+                uint8_t x = i * 128 / scale + shift;
                 for (uint8_t xx = ox; xx < x; xx++)
                 {
                     DrawVLine(Rssi2Y(rssi), DrawingEndY, xx, true);

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -871,15 +871,15 @@ uint8_t Rssi2Y(uint16_t rssi)
     static void DrawSpectrum()
     {
         uint16_t steps = GetStepsCount();
-        uint16_t scale = (steps > 128) ? 128 : steps;
-        uint16_t shift = 64 / steps + 1;
+        uint16_t bars = (steps > 128) ? 128 : steps;
+        uint16_t shift_graph = 64 / steps + 1; // to center bar on freq marker
         uint8_t ox = 0;
         for (uint8_t i = 0; i < 128; ++i)
         {
             uint16_t rssi = rssiHistory[i >> settings.stepsCount];
             if (rssi != RSSI_MAX_VALUE)
             {
-                uint8_t x = i * 128 / scale + shift;
+                uint8_t x = i * 128 / bars + shift_graph;
                 for (uint8_t xx = ox; xx < x; xx++)
                 {
                     DrawVLine(Rssi2Y(rssi), DrawingEndY, xx, true);

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -882,6 +882,7 @@ uint8_t Rssi2Y(uint16_t rssi)
             uint16_t rssi = rssiHistory[i >> settings.stepsCount];
             if (rssi != RSSI_MAX_VALUE)
             {
+                // stretch bars to fill the screen width
                 uint8_t x = i * 128 / bars + shift_graph;
                 for (uint8_t xx = ox; xx < x; xx++)
                 {


### PR DESCRIPTION
retain stretch of bars for short ranges, but after 128 samples, scale 1:1 to always fill the width of the screen.

![PXL_20250108_043043423](https://github.com/user-attachments/assets/2b1f37bd-fa05-4b2d-96d3-5587d1ecf02e)
![PXL_20250108_041908509](https://github.com/user-attachments/assets/9973761a-218a-4017-8e52-6994727f9840)
![PXL_20250108_042147948](https://github.com/user-attachments/assets/c6902527-3115-4724-a581-e272755330b0)
