### PR TITLE
Improve the compile-with-docker.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ This is the least demanding option as you don't have to install enything on your
 
 ### Docker build method
 
-If you have docker installed you can use [compile-with-docker.bat](./compile-with-docker.bat) (Windows) or [compile-with-docker.sh](./compile-with-docker.sh) (Linux/Mac), the output files are created in `compiled-firmware` folder. This method gives significantly smaller binaries, I've seen differences up to 1kb, so it can fit more functionalities this way. The challenge can be (or not) installing docker itself.
+If you have docker installed you can use [compile-with-docker.bat](./compile-with-docker.bat) (Windows) or [compile-with-docker.sh](./compile-with-docker.sh) (Linux/Mac), the output files are created in `compiled-firmware` folder. This method gives significantly smaller binaries, I've seen differences up to 1kb, so it can fit more functionalities this way. The challenge can be (or not) installing docker itself. You may need to uncomment and customize the DOCKER_NETWORK environment variable in the script.
 
 ### Windows environment build method
 

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 #export DOCKER_DEFAULT_PLATFORM=linux/amd64
+#export DOCKER_NETWORK="--network=host"
 IMAGE_NAME="uvk5"
 rm "${PWD}/compiled-firmware/*"
-docker build -t $IMAGE_NAME .
+echo "Building docker image $IMAGE_NAME"
+if ! docker build -t $DOCKER_NETWORK $IMAGE_NAME .
+then
+    echo "Failed to build docker image"
+    exit 1
+fi
 
 custom() {
     echo "Custom compilation..."


### PR DESCRIPTION
The docker build command in the compile-with-docker.sh may need the --network=<somenetwork> for the docker container to have network access.

In this patch, there are three modifications:

1. Docker build moved into if statement to bail out if it fails
2. Intruduced a DOCKER_NETWORK environment variable to optionally add the --network flag to docker build
3. Added a sentence to the readme in the compile with docker section about the potential need to add a network

Merci pour le beau travail !

Markus