### PR TITLE
Add more details to explain the S-Meter behavior in the F4HWN firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Special thanks to Jean-Cyrille F6IWW (2 times), Fabrice 14RC123, David F4BPP, Ol
     * Mid ~2W, 
     * High ~5W,
     * User (see SetPwr),
-* improve s-meter (IARU recommandations),
+* improve S-Meter (IARU Region 1 Technical Recommendation R.1 for VHF/UHF - [read more](https://hamwaves.com/decibel/en/)),
+   * S-Meter (S0/S9) Level EEPROM settings that were introduced in the Egzumer firmware are now ignored and replaced by hardcoded values to comply with the IARU Recommendation.     
 * improve bandscope (Spectrum Analyser):
     * add channel name,
     * add save of some spectrum parameters,


### PR DESCRIPTION
I had some questions regarding the way this firmware handles the S-Meter and apparently other people had similar questions:
- https://github.com/armel/uv-k5-firmware-custom/issues/62
- https://github.com/armel/uv-k5-firmware-custom/issues/81

After reading more and also digging into the firmware I understood that the approach armel applied is to completely ignore the S0/S9 level settings that were introduced by Egzumer as EEPROM variables and hardcode the correct values to comply with the VHF/UHF IARU Recommendation.

I added some notes to the README to make that a bit more explicit.