### PR TITLE
Apply code changes without image rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,3 @@ RUN pacman -Syyu arm-none-eabi-newlib --noconfirm
 RUN pacman -Syyu git --noconfirm
 RUN pacman -Syyu python-pip --noconfirm
 RUN pacman -Syyu python-crcmod --noconfirm
-WORKDIR /app
-COPY . .
-RUN git submodule update --init --recursive

--- a/compile-with-docker.bat
+++ b/compile-with-docker.bat
@@ -1,4 +1,4 @@
 @echo off
 docker build -t uvk5 .
-docker run --rm -v %CD%\compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make clean && make && cp f4hwn* compiled-firmware/"
+docker run --rm -v %CD%:/app uvk5 /bin/bash -c "cd /app && git submodule update --init --recursive && make -s clean && make -s"
 pause

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -9,46 +9,45 @@ mkdir -p "$FIRMWARE_DIR"
 # Clean previously compiled firmware files
 rm -f "$FIRMWARE_DIR"/*
 
-# Clean up old Docker artifacts
-echo "🧽 Cleaning up old Docker artifacts..."
-docker system prune -f --volumes >/dev/null 2>&1 || true
-
-# Always rebuild the Docker image to ensure latest code changes
-echo "⚙️ Rebuilding Docker image '$IMAGE_NAME'..."
-docker rmi "$IMAGE_NAME" 2>/dev/null || true
-if ! docker build --build-arg BUILDPLATFORM=linux/amd64 -t "$IMAGE_NAME" .; then
-    echo "❌ Failed to build docker image"
-    exit 1
+# Build image only if it doesn't already exist
+if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+    echo "Docker image '$IMAGE_NAME' not found, building..."
+    if ! docker build --build-arg BUILDPLATFORM=linux/amd64 -t "$IMAGE_NAME" .; then
+        echo "❌ Failed to build docker image"
+        exit 1
+    fi
 fi
 
 # ------------------ BUILD VARIANTS ------------------
 
 custom() {
     echo "🔧 Custom compilation..."
-    docker run --rm -v "$FIRMWARE_DIR:/app/compiled-firmware" "$IMAGE_NAME" /bin/bash -c "\
-        rm -f ./compiled-firmware/* && cd /app && make -s \
+    docker run --rm -v "${PWD}:/app" --user $(id -u):$(id -g) "$IMAGE_NAME" /bin/bash -c "\
+        cd /app && git submodule update --init --recursive && make -s clean && make -s \
         EDITION_STRING=Custom \
         TARGET=f4hwn.custom \
-        && cp f4hwn.custom* compiled-firmware/"
+        && mv f4hwn.custom* compiled-firmware/ \
+        && make -s clean"
 }
 
 standard() {
     echo "📦 Standard compilation..."
-    docker run --rm -v "$FIRMWARE_DIR:/app/compiled-firmware" "$IMAGE_NAME" /bin/bash -c "\
-        rm -f ./compiled-firmware/* && cd /app && make -s \
+    docker run --rm -v "${PWD}:/app" --user $(id -u):$(id -g) "$IMAGE_NAME" /bin/bash -c "\
+        cd /app && git submodule update --init --recursive && make -s clean && make -s \
         ENABLE_SPECTRUM=0 \
         ENABLE_FMRADIO=0 \
         ENABLE_AIRCOPY=0 \
         ENABLE_NOAA=0 \
         EDITION_STRING=Standard \
         TARGET=f4hwn.standard \
-        && cp f4hwn.standard* compiled-firmware/"
+        && mv f4hwn.standard* compiled-firmware/ \
+        && make -s clean"
 }
 
 bandscope() {
     echo "📺 Bandscope compilation..."
-    docker run --rm -v "$FIRMWARE_DIR:/app/compiled-firmware" "$IMAGE_NAME" /bin/bash -c "\
-        rm -f ./compiled-firmware/* && cd /app && make -s \
+    docker run --rm -v "${PWD}:/app" --user $(id -u):$(id -g) "$IMAGE_NAME" /bin/bash -c "\
+        cd /app && git submodule update --init --recursive && make -s clean && make -s \
         ENABLE_SPECTRUM=1 \
         ENABLE_FMRADIO=0 \
         ENABLE_VOX=0 \
@@ -61,13 +60,14 @@ bandscope() {
         ENABLE_FEAT_F4HWN_RESCUE_OPS=0 \
         EDITION_STRING=Bandscope \
         TARGET=f4hwn.bandscope \
-        && cp f4hwn.bandscope* compiled-firmware/"
+        && mv f4hwn.bandscope* compiled-firmware/ \
+        && make -s clean"
 }
 
 broadcast() {
     echo "📻 Broadcast compilation..."
-    docker run --rm -v "$FIRMWARE_DIR:/app/compiled-firmware" "$IMAGE_NAME" /bin/bash -c "\
-        cd /app && make -s \
+    docker run --rm -v "${PWD}:/app" --user $(id -u):$(id -g) "$IMAGE_NAME" /bin/bash -c "\
+        cd /app && git submodule update --init --recursive && make -s clean && make -s \
         ENABLE_SPECTRUM=0 \
         ENABLE_FMRADIO=1 \
         ENABLE_VOX=1 \
@@ -80,13 +80,14 @@ broadcast() {
         ENABLE_FEAT_F4HWN_RESCUE_OPS=0 \
         EDITION_STRING=Broadcast \
         TARGET=f4hwn.broadcast \
-        && cp f4hwn.broadcast* compiled-firmware/"
+        && mv f4hwn.broadcast* compiled-firmware/ \
+        && make -s clean"
 }
 
 basic() {
     echo "☘️ Basic compilation..."
-    docker run --rm -v "$FIRMWARE_DIR:/app/compiled-firmware" "$IMAGE_NAME" /bin/bash -c "\
-        cd /app && make -s \
+    docker run --rm -v "${PWD}:/app" --user $(id -u):$(id -g) "$IMAGE_NAME" /bin/bash -c "\
+        cd /app && git submodule update --init --recursive && make -s clean && make -s \
         ENABLE_SPECTRUM=1 \
         ENABLE_FMRADIO=1 \
         ENABLE_VOX=0 \
@@ -105,13 +106,14 @@ basic() {
         ENABLE_FEAT_F4HWN_RESCUE_OPS=0 \
         EDITION_STRING=Basic \
         TARGET=f4hwn.basic \
-        && cp f4hwn.basic* compiled-firmware/"
+        && mv f4hwn.basic* compiled-firmware/ \
+        && make -s clean"
 }
 
 rescueops() {
     echo "🚨 RescueOps compilation..."
-    docker run --rm -v "$FIRMWARE_DIR:/app/compiled-firmware" "$IMAGE_NAME" /bin/bash -c "\
-        cd /app && make -s \
+    docker run --rm -v "${PWD}:/app" --user $(id -u):$(id -g) "$IMAGE_NAME" /bin/bash -c "\
+        cd /app && git submodule update --init --recursive && make -s clean && make -s \
         ENABLE_SPECTRUM=0 \
         ENABLE_FMRADIO=0 \
         ENABLE_VOX=1 \
@@ -124,13 +126,14 @@ rescueops() {
         ENABLE_FEAT_F4HWN_RESCUE_OPS=1 \
         EDITION_STRING=RescueOps \
         TARGET=f4hwn.rescueops \
-        && cp f4hwn.rescueops* compiled-firmware/"
+        && mv f4hwn.rescueops* compiled-firmware/ \
+        && make -s clean"
 }
 
 game() {
     echo "🎮 Game compilation..."
-    docker run --rm -v "$FIRMWARE_DIR:/app/compiled-firmware" "$IMAGE_NAME" /bin/bash -c "\
-        cd /app && make -s \
+    docker run --rm -v "${PWD}:/app" --user $(id -u):$(id -g) "$IMAGE_NAME" /bin/bash -c "\
+        cd /app && git submodule update --init --recursive && make -s clean && make -s \
         ENABLE_SPECTRUM=0 \
         ENABLE_FMRADIO=1 \
         ENABLE_VOX=0 \
@@ -142,7 +145,8 @@ game() {
         ENABLE_FEAT_F4HWN_RESCUE_OPS=0 \
         EDITION_STRING=Game \
         TARGET=f4hwn.game \
-        && cp f4hwn.game* compiled-firmware/"
+        && mv f4hwn.game* compiled-firmware/ \
+        && make -s clean"
 }
 
 # ------------------ MENU ------------------


### PR DESCRIPTION
Same as #432, but on v4 dev branch !

> This PR allows building the firmware after modifying the code without having to delete and rebuild the Docker image.
> The change consists in mounting the project as a volume instead of copying it during the image build.
> To preserve the previous behavior, at the end of the build, the result is moved to "compiled-firmware" and then a make clean is performed.

_Needs to be tested on macOS  before being merged._
