### PR TITLE
test: use more optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ else
 endif
 
 ifeq ($(ENABLE_EXPERIMENTAL_CLFAGS),1)
-	CFLAGS += -funroll-loops
+	CFLAGS += -funroll-loops -ffat-lto-objects
 endif
 
 ifeq ($(ENABLE_LTO),1)


### PR DESCRIPTION
While digging through GCC documentation, I found another option...

With the `-ffat-lto-objects` option

```txt
📺 Compiling Bandscope...
   text	   data	    bss	    dec	    hex	filename
  60936	     52	   6576	  67564	  107ec	f4hwn.bandscope
📻 Compiling Broadcast...
   text	   data	    bss	    dec	    hex	filename
  60064	     20	   6244	  66328	  10318	f4hwn.broadcast
☘️ Compiling Basic...
   text	   data	    bss	    dec	    hex	filename
  61288	     52	   3340	  64680	   fca8	f4hwn.basic
🚨 Compiling RescueOps...
   text	   data	    bss	    dec	    hex	filename
  57804	     20	   6176	  64000	   fa00	f4hwn.rescueops
🎮 Compiling Game...
   text	   data	    bss	    dec	    hex	filename
  60792	     32	   3168	  63992	   f9f8	f4hwn.game
```

Without the `-ffat-lto-objects` option

```txt
📺 Compiling Bandscope...
   text	   data	    bss	    dec	    hex	filename
  60936	     52	   6576	  67564	  107ec	f4hwn.bandscope
📻 Compiling Broadcast...
   text	   data	    bss	    dec	    hex	filename
  60068	     20	   6244	  66332	  1031c	f4hwn.broadcast
☘️ Compiling Basic...
   text	   data	    bss	    dec	    hex	filename
  61296	     52	   3340	  64688	   fcb0	f4hwn.basic
🚨 Compiling RescueOps...
   text	   data	    bss	    dec	    hex	filename
  57804	     20	   6176	  64000	   fa00	f4hwn.rescueops
🎮 Compiling Game...
   text	   data	    bss	    dec	    hex	filename
  60796	     32	   3168	  63996	   f9fc	f4hwn.game
```

Only Bandscope and RescueOps stay the same (maybe enabled features need further optimizations).

And sorry for bombing you with so many PRs and ideas 8)-~