### PR TITLE
Further update on spectrum scope UX

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -470,9 +470,12 @@ static void ToggleAudio(bool on)
 
 static void ToggleRX(bool on)
 {
+    if (isListening == on) {
+        return;
+    }
     isListening = on;
 
-    RADIO_SetupAGC(on, lockAGC);
+    RADIO_SetupAGC(settings.modulationType == MODULATION_AM, lockAGC);
     BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, on);
 
     ToggleAudio(on);
@@ -1556,7 +1559,9 @@ static void UpdateStill()
     peak.rssi = scanInfo.rssi;
     AutoTriggerLevel();
 
-    ToggleRX(IsPeakOverLevel() || monitorMode);
+    if (IsPeakOverLevel() || monitorMode) {
+        ToggleRX(true);
+    }
 }
 
 static void UpdateListening()
@@ -1612,7 +1617,7 @@ static void Tick()
 #endif
 
 #ifdef ENABLE_SCAN_RANGES
-    if (gNextTimeslice_500ms)
+    if (gNextTimeslice_500ms && currentState == SPECTRUM)
     {
         gNextTimeslice_500ms = false;
 

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -978,36 +978,33 @@ static void DrawStatus()
 #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
 static void ShowChannelName(uint32_t f)
 {
-    unsigned int i;
-    char String[12];
-    memset(String, 0, sizeof(String));
+    static uint32_t channelF = 0;
+    static char channelName[12]; 
 
     if (isListening)
     {
-        for (i = 0; IS_MR_CHANNEL(i); i++)
-        {
-            if (RADIO_CheckValidChannel(i, false, 0))
+        if (f != channelF) {
+            channelF = f;
+            unsigned int i;
+            memset(channelName, 0, sizeof(channelName));
+            for (i = 0; IS_MR_CHANNEL(i); i++)
             {
-                if (SETTINGS_FetchChannelFrequency(i) == f)
+                if (RADIO_CheckValidChannel(i, false, 0))
                 {
-                    SETTINGS_FetchChannelName(String, i);
-                    if (String[0] != 0) {
-                        UI_PrintStringSmallBufferNormal(String, gStatusLine + 36);
-                        //GUI_DisplaySmallest(String, 127, 1, true, true);
+                    if (SETTINGS_FetchChannelFrequency(i) == channelF)
+                    {
+                        SETTINGS_FetchChannelName(channelName, i);
+                        break;
                     }
-                    break;
                 }
             }
+        }
+        if (channelName[0] != 0) {
+            UI_PrintStringSmallBufferNormal(channelName, gStatusLine + 36);
         }
     }
     else
     {
-        /*
-        for (int i = 36; i < 100; i++)
-        {
-            gStatusLine[i] = 0b00000000;
-        }
-        */
         memset(&gStatusLine[36], 0, 100 - 28);
     }
     ST7565_BlitStatusLine();
@@ -1338,9 +1335,6 @@ static void RenderStatus()
 {
     memset(gStatusLine, 0, sizeof(gStatusLine));
     DrawStatus();
-#ifdef ENABLE_FEAT_F4HWN_SPECTRUM
-    ShowChannelName(peak.f);
-#endif
     ST7565_BlitStatusLine();
 }
 

--- a/radio.c
+++ b/radio.c
@@ -1027,7 +1027,7 @@ void RADIO_SetModulation(ModulationMode_t modulation)
 void RADIO_SetupAGC(bool listeningAM, bool disable)
 {
     static uint8_t lastSettings;
-    uint8_t newSettings = (listeningAM << 1) | (disable << 1);
+    uint8_t newSettings = (listeningAM << 1) | (disable);
     if(lastSettings == newSettings)
         return;
     lastSettings = newSettings;


### PR DESCRIPTION
You guys made me go further and see what actually listenT has to do with and functionality around listening in spectrum scope. This way I have found some more issues:
1. squelch_tail interrupt alone is not enough, for airband a squelch_found interrupt is wanted as well to make it work smoother as it covers the phase-revert squelch control;
2. while listening AM in STILL mode after transmission has ended and rssi dropped below trigger level RX indicator is jumping on and off repeatedly and hardly goes stable;
3. in SPECTRUM and STILL mode looking up for channel name (assuming the radio has a lot of channels set with their names) can be so slow that UI becomes retarded to response to any key pressed.
All three have been fixed by following commits. Compiled and tested.