### PR TITLE
Fix spectrum UX (PR #489 reworked)

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -992,36 +992,33 @@ static void DrawStatus()
 #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
 static void ShowChannelName(uint32_t f)
 {
-    unsigned int i;
-    char String[12];
-    memset(String, 0, sizeof(String));
+    static uint32_t channelF = 0;
+    static char channelName[12]; 
 
     if (isListening)
     {
-        for (i = 0; IS_MR_CHANNEL(i); i++)
-        {
-            if (RADIO_CheckValidChannel(i, false, 0))
+        if (f != channelF) {
+            channelF = f;
+            unsigned int i;
+            memset(channelName, 0, sizeof(channelName));
+            for (i = 0; IS_MR_CHANNEL(i); i++)
             {
-                if (SETTINGS_FetchChannelFrequency(i) == f)
+                if (RADIO_CheckValidChannel(i, false, 0))
                 {
-                    SETTINGS_FetchChannelName(String, i);
-                    if (String[0] != 0) {
-                        UI_PrintStringSmallBufferNormal(String, gStatusLine + 36);
-                        //GUI_DisplaySmallest(String, 127, 1, true, true);
+                    if (SETTINGS_FetchChannelFrequency(i) == channelF)
+                    {
+                        SETTINGS_FetchChannelName(channelName, i);
+                        break;
                     }
-                    break;
                 }
             }
+        }
+        if (channelName[0] != 0) {
+            UI_PrintStringSmallBufferNormal(channelName, gStatusLine + 36);
         }
     }
     else
     {
-        /*
-        for (int i = 36; i < 100; i++)
-        {
-            gStatusLine[i] = 0b00000000;
-        }
-        */
         memset(&gStatusLine[36], 0, 100 - 28);
     }
     ST7565_BlitStatusLine();
@@ -1352,9 +1349,6 @@ static void RenderStatus()
 {
     memset(gStatusLine, 0, sizeof(gStatusLine));
     DrawStatus();
-#ifdef ENABLE_FEAT_F4HWN_SPECTRUM
-    ShowChannelName(peak.f);
-#endif
     ST7565_BlitStatusLine();
 }
 

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -1540,7 +1540,7 @@ static void UpdateScan()
         return;
     }
 
-    if (scanInfo.measurementsCount < 128)
+    if (! (scanInfo.measurementsCount >> 7)) // if (scanInfo.measurementsCount < 128)
         memset(&rssiHistory[scanInfo.measurementsCount], 0,
                sizeof(rssiHistory) - scanInfo.measurementsCount * sizeof(rssiHistory[0]));
 

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -477,9 +477,14 @@ static void ToggleAudio(bool on)
 
 static void ToggleRX(bool on)
 {
+    #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
+    if (isListening == on) {
+        return;
+    }
+    #endif
     isListening = on;
 
-    RADIO_SetupAGC(on, lockAGC);
+    RADIO_SetupAGC(settings.modulationType == MODULATION_AM, lockAGC);
     BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, on);
 
     ToggleAudio(on);
@@ -1568,7 +1573,9 @@ static void UpdateStill()
     peak.rssi = scanInfo.rssi;
     AutoTriggerLevel();
 
-    ToggleRX(IsPeakOverLevel() || monitorMode);
+    if (IsPeakOverLevel() || monitorMode) {
+        ToggleRX(true);
+    }
 }
 
 static void UpdateListening()

--- a/radio.c
+++ b/radio.c
@@ -1027,7 +1027,7 @@ void RADIO_SetModulation(ModulationMode_t modulation)
 void RADIO_SetupAGC(bool listeningAM, bool disable)
 {
     static uint8_t lastSettings;
-    uint8_t newSettings = (listeningAM << 1) | (disable << 1);
+    uint8_t newSettings = (listeningAM << 1) | disable;
     if(lastSettings == newSettings)
         return;
     lastSettings = newSettings;


### PR DESCRIPTION
This is #489 reimplemented from proper branch and with conditional compilation directives.
```
📺 Compiling Bandscope...
   text	   data	    bss	    dec	    hex	filename
  61064	     52	   6592	  67708	  1087c	f4hwn.bandscope
📻 Compiling Broadcast...
   text	   data	    bss	    dec	    hex	filename
  60064	     20	   6244	  66328	  10318	f4hwn.broadcast
☘️ Compiling Basic...
   text	   data	    bss	    dec	    hex	filename
  61384	     52	   3340	  64776	   fd08	f4hwn.basic
🚨 Compiling RescueOps...
   text	   data	    bss	    dec	    hex	filename
  57804	     20	   6176	  64000	   fa00	f4hwn.rescueops
🎮 Compiling Game...
   text	   data	    bss	    dec	    hex	filename
  60792	     32	   3168	  63992	   f9f8	f4hwn.game

```
All editions fit.