### PR TITLE
Revert "frequencies.c: TX_freq_check should return -1 or 0. Not 1."

### DIFF
--- a/frequencies.c
+++ b/frequencies.c
@@ -164,7 +164,7 @@ int32_t TX_freq_check(const uint32_t Frequency)
     // otherwise return '-1'
 
     if (Frequency < frequencyBandTable[0].lower || Frequency > frequencyBandTable[BAND_N_ELEM - 1].upper)
-        return -1;  // not allowed outside this range
+        return 1;  // not allowed outside this range
 
     if (Frequency >= BX4819_band1.upper && Frequency < BX4819_band2.lower)
         return -1;  // BX chip does not work in this range


### PR DESCRIPTION
Reverts armel/uv-k5-firmware-custom#440