### PR TITLE
Make it possible to scan multiple scanlists together (1+2, 1+3, and 2+3) and fix issue #143

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Special thanks to Jean-Cyrille F6IWW (2 times), Fabrice 14RC123, David F4BPP, Ol
         * scan list 1,
         * scan list 2,
         * scan list 3,
+        * scan list 1+2,
+        * scan list 1+3,
+        * scan list 2+3,
         * scan lists [1, 2, 3],
         * scan all (all channels with or without list),
     * add scan list shortcuts,
@@ -137,7 +140,7 @@ Special thanks to Jean-Cyrille F6IWW (2 times), Fabrice 14RC123, David F4BPP, Ol
     * add F + 8 to quickly switch backlight between BLMin and BLMax on demand (this bypass BackLt strategy),
     * add F + 9 to return to BackLt strategy,
     * add long press on MENU, in * SCAN mode, to temporarily exclude a memory channel,
-    * add short press on [0, 1, 2, 3, 4 or 5], in * SCAN mode, to dynamically change scan list.
+    * add short press on [0, 1, 2, 3, 4, 5, 6, 7, or 8], in * SCAN mode, to dynamically change scan list.
 * many fix:
     * squelch, 
     * s-meter,

--- a/app/action.c
+++ b/app/action.c
@@ -231,7 +231,7 @@ void ACTION_Scan(bool bRestart)
         }
 
         // channel mode. Keep scanning but toggle between scan lists
-        gEeprom.SCAN_LIST_DEFAULT = (gEeprom.SCAN_LIST_DEFAULT + 1) % 6;
+        gEeprom.SCAN_LIST_DEFAULT = (gEeprom.SCAN_LIST_DEFAULT + 1) % 9;
         #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
             SETTINGS_WriteCurrentState();
         #endif

--- a/app/main.c
+++ b/app/main.c
@@ -433,7 +433,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
         if (gScanStateDir != SCAN_OFF){
             switch(Key) {
-                case KEY_0...KEY_5:
+                case KEY_0...KEY_8:
                     gEeprom.SCAN_LIST_DEFAULT = Key;
                     #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
                         SETTINGS_WriteCurrentState();

--- a/app/menu.c
+++ b/app/menu.c
@@ -48,6 +48,14 @@
 
 uint8_t gUnlockAllTxConfCnt;
 
+// Preview state for live-applying CTCSS/DCS while scrolling
+static bool gCssPreviewActive = false;
+static uint8_t gCssPreviewMenu = 0; // one of MENU_R_CTCS, MENU_T_CTCS, MENU_R_DCS, MENU_T_DCS
+static uint8_t gCssOrigRxCodeType = 0;
+static uint8_t gCssOrigRxCode = 0;
+static uint8_t gCssOrigTxCodeType = 0;
+static uint8_t gCssOrigTxCode = 0;
+
 #ifdef ENABLE_F_CAL_MENU
     void writeXtalFreqCal(const int32_t value, const bool update_eeprom)
     {
@@ -1611,6 +1619,20 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
         {
             if (gInputBoxIndex == 0 || UI_MENU_GetCurrentMenuId() != MENU_OFFSET)
             {
+                // If we were previewing CSS, restore original on EXIT
+                if (gCssPreviewActive) {
+                    const uint8_t menuid = UI_MENU_GetCurrentMenuId();
+                    if (menuid == MENU_R_CTCS || menuid == MENU_R_DCS ||
+                        menuid == MENU_T_CTCS || menuid == MENU_T_DCS) {
+                        gTxVfo->freq_config_RX.CodeType = gCssOrigRxCodeType;
+                        gTxVfo->freq_config_RX.Code     = gCssOrigRxCode;
+                        gTxVfo->freq_config_TX.CodeType = gCssOrigTxCodeType;
+                        gTxVfo->freq_config_TX.Code     = gCssOrigTxCode;
+                        RADIO_SetupRegisters(true);
+                    }
+                    gCssPreviewActive = false;
+                }
+
                 gAskForConfirmation = 0;
                 gIsInSubMenu        = false;
                 gInputBoxIndex      = 0;
@@ -1683,6 +1705,20 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 
         gAskForConfirmation = 0;
         gIsInSubMenu        = true;
+
+        // Begin CSS preview capture when entering submenu
+        gCssPreviewActive = false;
+        gCssPreviewMenu = UI_MENU_GetCurrentMenuId();
+        if (gCssPreviewMenu == MENU_R_CTCS || gCssPreviewMenu == MENU_R_DCS ||
+            gCssPreviewMenu == MENU_T_CTCS || gCssPreviewMenu == MENU_T_DCS)
+        {
+            // Capture original RX/TX CSS state for rollback on EXIT
+            gCssOrigRxCodeType = gTxVfo->freq_config_RX.CodeType;
+            gCssOrigRxCode     = gTxVfo->freq_config_RX.Code;
+            gCssOrigTxCodeType = gTxVfo->freq_config_TX.CodeType;
+            gCssOrigTxCode     = gTxVfo->freq_config_TX.Code;
+            gCssPreviewActive  = true;
+        }
 
 //      if (UI_MENU_GetCurrentMenuId() != MENU_D_LIST)
         {
@@ -1770,12 +1806,17 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
                     gFlagAcceptSetting  = true;
                     gIsInSubMenu        = false;
                     gAskForConfirmation = 0;
+
+                    // Confirmed: end CSS preview session
+                    gCssPreviewActive = false;
             }
         }
         else
         {
             gFlagAcceptSetting = true;
             gIsInSubMenu       = false;
+            // Confirmed: end CSS preview session
+            gCssPreviewActive = false;
         }
     }
 
@@ -1945,6 +1986,42 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 
         default:
             MENU_ClampSelection(Direction);
+
+            // Live-apply CTCSS/DCS while scrolling in submenu
+            if (gIsInSubMenu && gCssPreviewActive) {
+                const uint8_t menuid = UI_MENU_GetCurrentMenuId();
+                FREQ_Config_t *pCfg = NULL;
+                if (menuid == MENU_R_CTCS || menuid == MENU_R_DCS) {
+                    pCfg = &gTxVfo->freq_config_RX;
+                } else if (menuid == MENU_T_CTCS || menuid == MENU_T_DCS) {
+                    pCfg = &gTxVfo->freq_config_TX;
+                }
+                if (pCfg) {
+                    if (menuid == MENU_R_CTCS || menuid == MENU_T_CTCS) {
+                        if (gSubMenuSelection == 0) {
+                            pCfg->CodeType = CODE_TYPE_OFF;
+                            pCfg->Code     = 0;
+                        } else {
+                            pCfg->CodeType = CODE_TYPE_CONTINUOUS_TONE;
+                            pCfg->Code     = gSubMenuSelection - 1;
+                        }
+                    } else { // DCS menus
+                        if (gSubMenuSelection == 0) {
+                            pCfg->CodeType = CODE_TYPE_OFF;
+                            pCfg->Code     = 0;
+                        } else if (gSubMenuSelection < 105) {
+                            pCfg->CodeType = CODE_TYPE_DIGITAL;
+                            pCfg->Code     = gSubMenuSelection - 1;
+                        } else {
+                            pCfg->CodeType = CODE_TYPE_REVERSE_DIGITAL;
+                            pCfg->Code     = gSubMenuSelection - 105;
+                        }
+                    }
+                    // Apply to hardware without saving
+                    RADIO_SetupRegisters(true);
+                }
+            }
+
             gRequestDisplayScreen = DISPLAY_MENU;
             return;
     }

--- a/radio.c
+++ b/radio.c
@@ -68,7 +68,7 @@ bool RADIO_CheckValidChannel(uint16_t channel, bool checkScanList, uint8_t scanL
     if (att.band > BAND7_470MHz)
         return false;
 
-    if (!checkScanList || scanList > 4)
+    if (!checkScanList || scanList > 8)
         return true;
 
     /*
@@ -98,18 +98,24 @@ bool RADIO_CheckValidChannel(uint16_t channel, bool checkScanList, uint8_t scanL
         (scanList == 1 && att.scanlist1 != 1) ||
         (scanList == 2 && att.scanlist2 != 1) ||
         (scanList == 3 && att.scanlist3 != 1) ||
-        (scanList == 4 && (att.scanlist1 == 0 && att.scanlist2 == 0 && att.scanlist3 == 0))) {
+        (scanList == 4 && (att.scanlist1 != 1 && att.scanlist2 != 1)) || /* 1+2 */
+        (scanList == 5 && (att.scanlist1 != 1 && att.scanlist3 != 1)) || /* 1+3 */
+        (scanList == 6 && (att.scanlist2 != 1 && att.scanlist3 != 1)) || /* 2+3 */
+        (scanList == 7 && (att.scanlist1 == 0 && att.scanlist2 == 0 && att.scanlist3 == 0)) /* 1|2|3 */) {
         return false;
     }
 
     //return true;
 
     // I don't understand what this code is for...
-    
-    const uint8_t PriorityCh1 = gEeprom.SCANLIST_PRIORITY_CH1[scanList - 1];
-    const uint8_t PriorityCh2 = gEeprom.SCANLIST_PRIORITY_CH2[scanList - 1];
+    // Exclude the priority channels when scanning an individual list (1..3)
+    if (scanList >= 1 && scanList <= 3) {
+        const uint8_t PriorityCh1 = gEeprom.SCANLIST_PRIORITY_CH1[scanList - 1];
+        const uint8_t PriorityCh2 = gEeprom.SCANLIST_PRIORITY_CH2[scanList - 1];
+        return PriorityCh1 != channel && PriorityCh2 != channel;
+    }
 
-    return PriorityCh1 != channel && PriorityCh2 != channel;
+    return true;
 }
 
 uint8_t RADIO_FindNextChannel(uint8_t Channel, int8_t Direction, bool bCheckScanList, uint8_t VFO)

--- a/settings.c
+++ b/settings.c
@@ -245,7 +245,7 @@ void SETTINGS_InitEEPROM(void)
 
     // 0F18..0F1F
     EEPROM_ReadBuffer(0x0F18, Data, 8);
-    gEeprom.SCAN_LIST_DEFAULT = (Data[0] < 6) ? Data[0] : 0;  // we now have 'all' channel scan option
+    gEeprom.SCAN_LIST_DEFAULT = (Data[0] < 9) ? Data[0] : 0;  // support up to 9 scan modes (0..8)
 
     // Fake data
     /*

--- a/ui/status.c
+++ b/ui/status.c
@@ -107,10 +107,22 @@ void UI_DisplayStatus()
                     case 3:
                         memcpy(line + 0, BITMAP_ScanList3, sizeof(BITMAP_ScanList3));
                         break;
-                    case 4:
+                    case 4: /* 1+2 */
+                        memcpy(line + 0, BITMAP_ScanList1, sizeof(BITMAP_ScanList1));
+                        memcpy(line + 7, BITMAP_ScanList2, sizeof(BITMAP_ScanList2));
+                        break;
+                    case 5: /* 1+3 */
+                        memcpy(line + 0, BITMAP_ScanList1, sizeof(BITMAP_ScanList1));
+                        memcpy(line + 7, BITMAP_ScanList3, sizeof(BITMAP_ScanList3));
+                        break;
+                    case 6: /* 2+3 */
+                        memcpy(line + 0, BITMAP_ScanList2, sizeof(BITMAP_ScanList2));
+                        memcpy(line + 7, BITMAP_ScanList3, sizeof(BITMAP_ScanList3));
+                        break;
+                    case 7: /* 1+2+3 */
                         memcpy(line + 0, BITMAP_ScanList123, sizeof(BITMAP_ScanList123));
                         break;
-                    case 5:
+                    case 8: /* Everything */
                         memcpy(line + 0, BITMAP_ScanListAll, sizeof(BITMAP_ScanListAll));
                         break;
                 }


### PR DESCRIPTION
Small changes to make it possible to scan multiple scanlists, and associated README updates. 

Buttons have new functionality when scanning channels:

4 - scan channels on list 1 and 2
5 - scan channels on list 1 and 3
6 - scan channels on list 2 and 3

The other keys have been moved down like so:

7 - scan 1, 2, 3
8 - scan all

Tested by making a build on Gtihub codespaces and flashing it on my radio. On this radio I assigned PMR1-4 to scanlist 1, 5-8 to scanlist 2, and 9 to 12 to scanlist 3. Using a second radio I then transmitted on each PMR frequency while having different scanlist settings enabled and the behaviour was as expected. 

This PR also addresses issue #143 