### PR TITLE
UI improvements, backlight toggle in FM radio, code optimization

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1522,7 +1522,6 @@ void cancelUserInputModes(void)
         gWasFKeyPressed     = false;
         gInputBoxIndex      = 0;
         gKeyInputCountdown  = 0;
-        gBeepToPlay         = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         gUpdateStatus       = true;
         gUpdateDisplay      = true;
     }
@@ -1552,8 +1551,6 @@ void APP_TimeSlice500ms(void)
                 if (gBeepToPlay == BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL) {
                     AUDIO_PlayBeep(gBeepToPlay);
                 }
-
-                SETTINGS_SaveVfoIndices();
             }
 
             cancelUserInputModes();
@@ -1919,6 +1916,7 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
             // cancel user input
             cancelUserInputModes();
+            gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
 
             if (gMonitor)
                 ACTION_Monitor(); //turn off the monitor

--- a/app/fm.c
+++ b/app/fm.c
@@ -376,6 +376,14 @@ static void Key_FUNC(KEY_Code_t Key, uint8_t state)
                 else
                     gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
                 break;
+            
+            case KEY_8:
+                ACTION_BackLightOnDemand();
+                break;
+
+            case KEY_9:
+                ACTION_BackLight();
+                break;
 
             case KEY_STAR:
                 ACTION_Scan(autoScan);

--- a/app/generic.c
+++ b/app/generic.c
@@ -39,7 +39,7 @@
 
 void GENERIC_Key_F(bool bKeyPressed, bool bKeyHeld)
 {
-    if (gInputBoxIndex > 0) {
+    if (gInputBoxIndex > 0 || gScreenToDisplay == DISPLAY_MENU) {
         if (!bKeyHeld && bKeyPressed) // short pressed
             gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         return;

--- a/app/main.c
+++ b/app/main.c
@@ -105,8 +105,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
         gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         return;
     }
-    
-    gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
     switch (Key) {
         case KEY_0:
@@ -203,7 +201,7 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
             #endif
             COMMON_SwitchVFOMode();
             if (beep)
-                gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
             break;
 
@@ -414,7 +412,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
                 gWasFKeyPressed = false;
                 gUpdateStatus   = true;
 
-                processFKeyFunction(Key, false);
+                processFKeyFunction(Key, true);
             }
         }
         return;
@@ -591,7 +589,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
     }
     #endif
 
-    processFKeyFunction(Key, true);
+    processFKeyFunction(Key, false);
 }
 
 static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
@@ -709,6 +707,9 @@ static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
     }
 
     if (!bKeyPressed && !gDTMF_InputMode) { // menu key released
+        gKeyInputCountdown = 1;
+        channelMoveSwitch();
+
         const bool bFlag = !gInputBoxIndex;
         gInputBoxIndex   = 0;
 
@@ -857,7 +858,7 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 
     if (bKeyHeld || !bKeyPressed) { // key held or released
         if (gInputBoxIndex > 0)
-            return; // leave if input box active
+            gInputBoxIndex = 0;
 
         if (!bKeyPressed) {
             if (!bKeyHeld || IS_FREQ_CHANNEL(Channel))
@@ -871,10 +872,6 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
         }
     }
     else { // short pressed
-        if (gInputBoxIndex > 0) {
-            gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
-            return;
-        }
         gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
     }
 

--- a/app/main.c
+++ b/app/main.c
@@ -219,7 +219,7 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
             break;
 
         case KEY_5:
-            if(beep) {
+            if(!beep) {
 #ifdef ENABLE_NOAA
                 if (!IS_NOAA_CHANNEL(gTxVfo->CHANNEL_SAVE)) {
                     gEeprom.ScreenChannel[Vfo] = gEeprom.NoaaChannel[gEeprom.TX_VFO];


### PR DESCRIPTION
**Hello. I would like to share a few code modification suggestions that fix minor bugs or add new features. In my spare time, I tested various combinations and possibilities of Quansheng. Here are my changes:**

## Fixed incorrect beeps after channel change

Resolved an issue where pressing [KEY_SIDE1], [KEY_SIDE2], or [* SCAN] immediately after confirming a channel input with timeout in MR mode would play an error beep followed by a confirmation beep.

> 1. Enter the channel number in MR mode.
> 2. Wait for channel confirm (timeout).
> 3. Press \[KEY\_SIDE1], \[KEY\_SIDE2], or \[\* SCAN].

## Fixed VFO/MR toggle sound

Changing the VFO/MR mode (F+3) now correctly plays a confirmation beep instead of an error beep.

## Added error beep in MENU when attempting to use the function key.

Pressing the function key [F#] while inside the MENU (except when inputting a name in [ChName, etc.]) will now correctly play an error beep to indicate an invalid action. Previously, an error beep was played when a single digit was entered (a confirmation beep was played for a two-digit number).

> 1. Press MENU to enter settings.
> 2. Press \[F#] - a confirmation beep will play.
> 3. Enter any digit (1-9).
> 4. Press \[F#] - a error beep will play.
> 5. Enter any digit again (for a two-digit position in the settings).
> 6. Press \[F#] - a confirmation beep will play.

## Removed double playback of confirmation beep when using a function key with a number.

Previously, pressing the [F#] function key with a number played the sound twice. Now the sound plays once.

## Added the ability to change channels using the arrow keys when changing channels using numbers.

I once suggested this change, but it was rejected. I think it's quite a useful feature that improves navigation within the channel. For example, if a user makes a mistake when entering a channel, they can use the arrows to quickly correct the error. Otherwise, they would have to wait for the channel to be approved.

>1. Enter the channel number in MR mode.
>2. Use the up/down arrows. The channel will be changed and the input mode will be canceled.

## Added manual backlight control in FM radio mode.

In FM radio mode, the [F+8] and [F+9] functions are not used, so I came up with the idea of enabling manual control of the backlight.

>1. Enter FM radio mode.
>2. Try using \[F+8] or \[F+9].

## Removed redundant SETTINGS_SaveVfoIndices() from APP_TimeSlice500ms(void)

Removed redundant SETTINGS_SaveVfoIndices() from APP_TimeSlice500ms(void) because it is not needed (SETTINGS_SaveVfoIndices() is in the ChannelMove() function, and ChannelMove() is executed in APP_TimeSlice500ms(void)).

---

**I hope I have been helpful and that my suggestions will be accepted. I look forward to hearing your opinion. The same changes could be introduced in UV-K1/UV-K5(V3) Fusion version .**

Modified code: https://github.com/armel/uv-k5-firmware-custom/commit/046a936ff8db4058b0890f4cfff40fb258edbb8f + comment below

<details> 
  <summary>Postscriptum:</summary>
   I am interested in the new version of Quansheng UVK5 V3, so I decided to get rid of the old version and buy the new one. When it arrives, I will immediately want to install F4HWN v5.1.0.
</details>