### PR TITLE
Fix channels being skipped while scanning

### DIFF
--- a/radio.c
+++ b/radio.c
@@ -105,11 +105,12 @@ bool RADIO_CheckValidChannel(uint16_t channel, bool checkScanList, uint8_t scanL
     //return true;
 
     // I don't understand what this code is for...
-    
+    // What happens when scanList equals 0 or 4? Most likely reading a 0 value, which means channel number 0 will be skipped.
     const uint8_t PriorityCh1 = gEeprom.SCANLIST_PRIORITY_CH1[scanList - 1];
     const uint8_t PriorityCh2 = gEeprom.SCANLIST_PRIORITY_CH2[scanList - 1];
 
-    return PriorityCh1 != channel && PriorityCh2 != channel;
+    return (scanList == 0 || scanList == 4) || // the proposed fix
+    (PriorityCh1 != channel && PriorityCh2 != channel);
 }
 
 uint8_t RADIO_FindNextChannel(uint8_t Channel, int8_t Direction, bool bCheckScanList, uint8_t VFO)

--- a/radio.c
+++ b/radio.c
@@ -102,15 +102,14 @@ bool RADIO_CheckValidChannel(uint16_t channel, bool checkScanList, uint8_t scanL
         return false;
     }
 
-    //return true;
-
-    // I don't understand what this code is for...
     // What happens when scanList equals 0 or 4? Most likely reading a 0 value, which means channel number 0 will be skipped.
+    if(scanList == 0 || scanList == 4) // the proposed fix
+        return true;
+
     const uint8_t PriorityCh1 = gEeprom.SCANLIST_PRIORITY_CH1[scanList - 1];
     const uint8_t PriorityCh2 = gEeprom.SCANLIST_PRIORITY_CH2[scanList - 1];
 
-    return (scanList == 0 || scanList == 4) || // the proposed fix
-    (PriorityCh1 != channel && PriorityCh2 != channel);
+    return PriorityCh1 != channel && PriorityCh2 != channel;
 }
 
 uint8_t RADIO_FindNextChannel(uint8_t Channel, int8_t Direction, bool bCheckScanList, uint8_t VFO)


### PR DESCRIPTION
Hello, 

While scanning a scanlist in some configurations, the channel number 0 (M1) in memory is skipped. 
Hard to explain, but it is probably related to a read outside the intended range : the arrays gEeprom.SCANLIST_PRIORITY_CH1/2 are of size 3 (so index 0, 1, 2 are readable), but when scanList == 0 or 4, we read index 255 and index 3, which **may** return the 0 value, skipping channel 0. Please read comments in the commit for more info.

In my case, the PMR01 channel lies on memory location 0 (M1), in scanList 0 (PMR01->PMR16), and is always skipped.

Thanks in advance.