### PR TITLE
Merging most of the changes and refactoring from version V3

### DIFF
--- a/app/action.c
+++ b/app/action.c
@@ -313,19 +313,23 @@ void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         return;
     }
 
-    enum ACTION_OPT_t funcShort = ACTION_OPT_NONE;
-    enum ACTION_OPT_t funcLong  = ACTION_OPT_NONE;
+    enum ACTION_OPT_t func = ACTION_OPT_NONE;
     switch(Key) {
         case KEY_SIDE1:
-            funcShort = gEeprom.KEY_1_SHORT_PRESS_ACTION;
-            funcLong  = gEeprom.KEY_1_LONG_PRESS_ACTION;
+            if (bKeyHeld)
+                func = gEeprom.KEY_1_LONG_PRESS_ACTION;
+            else
+                func = gEeprom.KEY_1_SHORT_PRESS_ACTION;
             break;
         case KEY_SIDE2:
-            funcShort = gEeprom.KEY_2_SHORT_PRESS_ACTION;
-            funcLong  = gEeprom.KEY_2_LONG_PRESS_ACTION;
+            if (bKeyHeld)
+                func = gEeprom.KEY_2_LONG_PRESS_ACTION;
+            else
+                func = gEeprom.KEY_2_SHORT_PRESS_ACTION;
             break;
         case KEY_MENU:
-            funcLong  = gEeprom.KEY_M_LONG_PRESS_ACTION;
+            if (bKeyHeld)
+                func = gEeprom.KEY_M_LONG_PRESS_ACTION;
             break;
         default:
             break;
@@ -341,17 +345,14 @@ void ACTION_Handle(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
     if(!(bKeyHeld && !bKeyPressed)) // don't beep on released after hold
         gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
-    if (bKeyHeld || bKeyPressed) // held
+    if (bKeyHeld && !bKeyPressed) // button released after hold
     {
-        funcShort = funcLong;
-
-        if (!bKeyPressed) //ignore release if held
-            return;
+        return;
     }
 
     // held or released after short press beyond this point
 
-    action_opt_table[funcShort]();
+    action_opt_table[func]();
 }
 
 

--- a/app/action.c
+++ b/app/action.c
@@ -497,17 +497,13 @@ void ACTION_RxMode(void)
 {
     static bool cycle = 0;
 
-    switch(cycle) {
-        case 0:
-            gEeprom.DUAL_WATCH = !gEeprom.DUAL_WATCH;
-            cycle = 1;
-            break;
-        case 1:
-            gEeprom.CROSS_BAND_RX_TX = !gEeprom.CROSS_BAND_RX_TX;
-            cycle = 0;
-            break;
+    if (cycle) {
+        gEeprom.CROSS_BAND_RX_TX = !gEeprom.CROSS_BAND_RX_TX;
+    } else {
+        gEeprom.DUAL_WATCH = !gEeprom.DUAL_WATCH;
     }
 
+    cycle = !cycle;
     ACTION_Update();
 }
 
@@ -517,22 +513,18 @@ void ACTION_MainOnly(void)
     static uint8_t dw = 0;
     static uint8_t cb = 0;
 
-    switch(cycle) {
-        case 0:
-            dw = gEeprom.DUAL_WATCH;
-            cb = gEeprom.CROSS_BAND_RX_TX;
+    if (cycle) {
+        gEeprom.DUAL_WATCH = dw;
+        gEeprom.CROSS_BAND_RX_TX = cb;
+    } else {
+        dw = gEeprom.DUAL_WATCH;
+        cb = gEeprom.CROSS_BAND_RX_TX;
 
-            gEeprom.DUAL_WATCH = 0;
-            gEeprom.CROSS_BAND_RX_TX = 0;
-            cycle = 1;
-            break;
-        case 1:
-            gEeprom.DUAL_WATCH = dw;
-            gEeprom.CROSS_BAND_RX_TX = cb;
-            cycle = 0;
-            break;
+        gEeprom.DUAL_WATCH = 0;
+        gEeprom.CROSS_BAND_RX_TX = 0;
     }
 
+    cycle = !cycle;
     ACTION_Update();
 }
 
@@ -544,9 +536,10 @@ void ACTION_Ptt(void)
 void ACTION_Wn(void)
 {
     #ifdef ENABLE_FEAT_F4HWN_NARROWER
-        bool narrower = 0;
         if (FUNCTION_IsRx())
         {
+            bool narrower = 0;
+            
             gRxVfo->CHANNEL_BANDWIDTH = (gRxVfo->CHANNEL_BANDWIDTH == 0) ? 1: 0;
             if(gRxVfo->CHANNEL_BANDWIDTH == BANDWIDTH_NARROW && gSetting_set_nfm == 1)
             {
@@ -559,20 +552,6 @@ void ACTION_Wn(void)
                 BK4819_SetFilterBandwidth(gRxVfo->CHANNEL_BANDWIDTH + narrower, false);
             #endif
         }
-        else
-        {
-            gTxVfo->CHANNEL_BANDWIDTH = (gTxVfo->CHANNEL_BANDWIDTH == 0) ? 1: 0;
-            if(gTxVfo->CHANNEL_BANDWIDTH == BANDWIDTH_NARROW && gSetting_set_nfm == 1)
-            {
-                narrower = 1;
-            }
-
-            #ifdef ENABLE_AM_FIX
-                BK4819_SetFilterBandwidth(gTxVfo->CHANNEL_BANDWIDTH, true);
-            #else
-                BK4819_SetFilterBandwidth(gTxVfo->CHANNEL_BANDWIDTH, false);
-            #endif
-        }
     #else
         if (FUNCTION_IsRx())
         {
@@ -583,16 +562,17 @@ void ACTION_Wn(void)
                 BK4819_SetFilterBandwidth(gRxVfo->CHANNEL_BANDWIDTH, false);
             #endif
         }
+    #endif
         else
         {
             gTxVfo->CHANNEL_BANDWIDTH = (gTxVfo->CHANNEL_BANDWIDTH == 0) ? 1: 0;
+            
             #ifdef ENABLE_AM_FIX
                 BK4819_SetFilterBandwidth(gTxVfo->CHANNEL_BANDWIDTH, true);
             #else
                 BK4819_SetFilterBandwidth(gTxVfo->CHANNEL_BANDWIDTH, false);
             #endif
         }
-    #endif
 }
 
 void ACTION_BackLight(void)

--- a/app/aircopy.c
+++ b/app/aircopy.c
@@ -52,9 +52,20 @@ static void AIRCOPY_clear()
         crc[i] = 0;
     }
     #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-        getScreenShot(true);
+        SCREENSHOT_Update(true);
     #endif
 }
+
+static inline void AIRCOPY_Obfuscation(void)
+{
+    for (unsigned int i = 0; i < 34; i++) {
+        g_FSK_Buffer[i + 1] ^= Obfuscation[i % 8];
+    }
+}
+
+// ============================================================================
+// Send/Receive Functions
+// ============================================================================
 
 bool AIRCOPY_SendMessage(void)
 {
@@ -74,14 +85,12 @@ bool AIRCOPY_SendMessage(void)
 
     g_FSK_Buffer[34] = CRC_Calculate(&g_FSK_Buffer[1], 2 + 64);
 
-    for (unsigned int i = 0; i < 34; i++) {
-        g_FSK_Buffer[i + 1] ^= Obfuscation[i % 8];
-    }
+    AIRCOPY_Obfuscation();
 
     if (++gAirCopyBlockNumber >= 0x78) {
         gAircopyState = AIRCOPY_COMPLETE;
         #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-            getScreenShot(false);
+            SCREENSHOT_Update(false);
         #endif
         //NVIC_SystemReset();
     }
@@ -115,12 +124,10 @@ void AIRCOPY_StorePacket(void)
         return;
     }
 
-    for (unsigned int i = 0; i < 34; i++) {
-        g_FSK_Buffer[i + 1] ^= Obfuscation[i % 8];
-    }
+    AIRCOPY_Obfuscation();
 
-    uint16_t CRC = CRC_Calculate(&g_FSK_Buffer[1], 2 + 64);
-    if (g_FSK_Buffer[34] != CRC) {
+    uint16_t Crc = CRC_Calculate(&g_FSK_Buffer[1], 2 + 64);
+    if (g_FSK_Buffer[34] != Crc) {
         gErrorsDuringAirCopy++;
         return;
     }
@@ -142,22 +149,33 @@ void AIRCOPY_StorePacket(void)
     if (Offset == 0x1E00) {
         gAircopyState = AIRCOPY_COMPLETE;
         #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-            getScreenShot(false);
+            SCREENSHOT_Update(false);
         #endif
     }
 
     gAirCopyBlockNumber++;
 }
 
-static void AIRCOPY_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
+static void AIRCOPY_InitTransfer(bool isSendMode)
 {
-    if (bKeyHeld || !bKeyPressed) {
-        return;
-    }
+    gAircopyStep = 1;
+    gFSKWriteIndex = 0;
+    gAirCopyBlockNumber = 0;
+    gInputBoxIndex = 0;
+    gAirCopyIsSendMode = isSendMode;
 
+    AIRCOPY_clear();
+    
+    gAircopyState = AIRCOPY_TRANSFER;
+}
+
+// ============================================================================
+// Key Processing
+// ============================================================================
+
+static void AIRCOPY_Key_DIGITS(KEY_Code_t Key)
+{
     INPUTBOX_Append(Key);
-
-    gRequestDisplayScreen = DISPLAY_AIRCOPY;
 
     if (gInputBoxIndex < 6) {
 #ifdef ENABLE_VOICE
@@ -193,82 +211,58 @@ static void AIRCOPY_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         BK4819_ResetFSK();
         return;
     }
-
-    gRequestDisplayScreen = DISPLAY_AIRCOPY;
 }
 
-static void AIRCOPY_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
+static void AIRCOPY_Key_EXIT()
 {
-    if (bKeyHeld || !bKeyPressed) {
-        return;
-    }
-
     if (gInputBoxIndex == 0) {
-        gAircopyStep = 1;
-        gFSKWriteIndex = 0;
-        gAirCopyBlockNumber = 0;
-        gInputBoxIndex = 0;
+        AIRCOPY_InitTransfer(0); // Mode: Receive
         gErrorsDuringAirCopy = lErrorsDuringAirCopy = 0;
-        gAirCopyIsSendMode = 0;
-
-        AIRCOPY_clear();
 
         BK4819_PrepareFSKReceive();
-
-        gAircopyState = AIRCOPY_TRANSFER;
+        
     } else {
         gInputBox[--gInputBoxIndex] = 10;
     }
-
-    gRequestDisplayScreen = DISPLAY_AIRCOPY;
 }
 
-static void AIRCOPY_Key_MENU(bool bKeyPressed, bool bKeyHeld)
+static void AIRCOPY_Key_MENU()
 {
-    if (bKeyHeld || !bKeyPressed) {
-        return;
-    }
-
-    gAircopyStep = 1;
-    gFSKWriteIndex = 0;
-    gAirCopyBlockNumber = 0;
-    gInputBoxIndex = 0;
-    gAirCopyIsSendMode = 1;
+    AIRCOPY_InitTransfer(1); // Mode: Send
+    
     g_FSK_Buffer[0] = 0xABCD;
     g_FSK_Buffer[1] = 0;
     g_FSK_Buffer[35] = 0xDCBA;
-
-    AIRCOPY_clear();
-
-    GUI_DisplayScreen();
-
-    gAircopyState = AIRCOPY_TRANSFER;
 }
 
 void AIRCOPY_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 {
+    if (bKeyHeld || !bKeyPressed) {
+        return;
+    }
+
+    if (Key != KEY_PTT) {
+        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
+    }
+
     switch (Key) {
-    case KEY_0:
-    case KEY_1:
-    case KEY_2:
-    case KEY_3:
-    case KEY_4:
-    case KEY_5:
-    case KEY_6:
-    case KEY_7:
-    case KEY_8:
-    case KEY_9:
-        AIRCOPY_Key_DIGITS(Key, bKeyPressed, bKeyHeld);
+    case KEY_0...KEY_9:
+        AIRCOPY_Key_DIGITS(Key);
         break;
     case KEY_MENU:
-        AIRCOPY_Key_MENU(bKeyPressed, bKeyHeld);
+        AIRCOPY_Key_MENU();
         break;
     case KEY_EXIT:
-        AIRCOPY_Key_EXIT(bKeyPressed, bKeyHeld);
+        AIRCOPY_Key_EXIT();
+        break;
+    case KEY_PTT:
         break;
     default:
+        gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         break;
     }
+
+    gRequestDisplayScreen = DISPLAY_AIRCOPY;
 }
 
 #endif

--- a/app/aircopy.c
+++ b/app/aircopy.c
@@ -41,7 +41,7 @@ static const uint16_t Obfuscation[8] = { 0x6C16, 0xE614, 0x912E, 0x400D, 0x3521,
 AIRCOPY_State_t gAircopyState;
 uint16_t gAirCopyBlockNumber;
 uint16_t gErrorsDuringAirCopy;
-uint8_t gAirCopyIsSendMode;
+bool     gAirCopyIsSendMode;
 
 uint16_t g_FSK_Buffer[36];
 

--- a/app/aircopy.h
+++ b/app/aircopy.h
@@ -33,7 +33,7 @@ typedef enum AIRCOPY_State_t AIRCOPY_State_t;
 extern AIRCOPY_State_t gAircopyState;
 extern uint16_t        gAirCopyBlockNumber;
 extern uint16_t        gErrorsDuringAirCopy;
-extern uint8_t         gAirCopyIsSendMode;
+extern bool            gAirCopyIsSendMode;
 
 extern uint16_t        g_FSK_Buffer[36];
 

--- a/app/app.c
+++ b/app/app.c
@@ -1473,7 +1473,6 @@ void cancelUserInputModes(void)
     if (gDTMF_InputMode || gDTMF_InputBox_Index > 0)
     {
         DTMF_clear_input_box();
-        gBeepToPlay           = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         gRequestDisplayScreen = DISPLAY_MAIN;
         gUpdateDisplay        = true;
     }
@@ -1515,6 +1514,7 @@ void APP_TimeSlice500ms(void)
             }
 
             cancelUserInputModes();
+            gHasVfoBackup = false;
         }
     }
 
@@ -1883,7 +1883,7 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
             // cancel user input
             cancelUserInputModes();
-            gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+            gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
             if (gMonitor)
                 ACTION_Monitor(); //turn off the monitor

--- a/app/app.c
+++ b/app/app.c
@@ -273,18 +273,9 @@ static void HandleReceive(void)
             break;
 
         case CODE_TYPE_CONTINUOUS_TONE:
-            if (gFoundCTCSS && gFoundCTCSSCountdown_10ms == 0)
-            {
-                gFoundCTCSS = false;
-                gFoundCDCSS = false;
-                Mode        = END_OF_RX_MODE_END;
-                goto Skip;
-            }
-            break;
-
         case CODE_TYPE_DIGITAL:
         case CODE_TYPE_REVERSE_DIGITAL:
-            if (gFoundCDCSS && gFoundCDCSSCountdown_10ms == 0)
+            if ((gFoundCTCSS && gFoundCTCSSCountdown_10ms == 0) || (gFoundCDCSS && gFoundCDCSSCountdown_10ms == 0))
             {
                 gFoundCTCSS = false;
                 gFoundCDCSS = false;
@@ -544,7 +535,17 @@ void APP_StartListening(FUNCTION_Type_t function)
         gEeprom.DUAL_WATCH != DUAL_WATCH_OFF)
     {   // not scanning, dual watch is enabled
 
-        gDualWatchCountdown_10ms = dual_watch_count_after_2_10ms;
+        //gDualWatchCountdown_10ms = dual_watch_count_after_2_10ms;
+
+        const bool isMainTxDualRx =
+        (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF) &&
+        (gEeprom.CROSS_BAND_RX_TX != CROSS_BAND_OFF);
+
+        // Use a short hold only for MAIN TX DUAL RX, keep legacy hold otherwise
+        gDualWatchCountdown_10ms = isMainTxDualRx
+            ? dual_watch_count_after_2_10ms / 4 // Short timer = 420 / 4 ...
+            : dual_watch_count_after_2_10ms;
+
         gScheduleDualWatch       = false;
 
         // when crossband is active only the main VFO should be used for TX
@@ -1125,14 +1126,7 @@ void APP_Update(void)
             // go back to sleep
 
 #ifdef ENABLE_FEAT_F4HWN_SLEEP
-            if(gWakeUp)
-            {
-                gPowerSave_10ms = gEeprom.BATTERY_SAVE * 200; // deep sleep now indexed on BatSav
-            }
-            else
-            {
-                gPowerSave_10ms = gEeprom.BATTERY_SAVE * 10;
-            }
+            gPowerSave_10ms = gEeprom.BATTERY_SAVE * (gWakeUp ? 200 : 10); // deep sleep now indexed on BatSav
 #else
             gPowerSave_10ms = gEeprom.BATTERY_SAVE * 10;
 #endif
@@ -1157,8 +1151,21 @@ void APP_Update(void)
     }
 }
 
+void StopTransmitting(void) {
+    ProcessKey(KEY_PTT, false, false);
+    gPttIsPressed = false;
+    if (gKeyReading1 != KEY_INVALID)
+        gPttWasReleased = true;
+
+    #ifdef ENABLE_FEAT_F4HWN
+        #if defined(ENABLE_FEAT_F4HWN_CTR) || defined(ENABLE_FEAT_F4HWN_INV)
+        ST7565_ContrastAndInv();
+        #endif
+    #endif
+}
+
 // called every 10ms
-static void CheckKeys(void)
+void CheckKeys(void)
 {
 #ifdef ENABLE_DTMF_CALLING
     if(gSetting_KILLED){
@@ -1173,75 +1180,58 @@ static void CheckKeys(void)
 #endif
 
 // -------------------- PTT ------------------------
+    const bool serialConfigInProgress = SerialConfigInProgress();
+    const bool isPressed = !GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) && !serialConfigInProgress;
+
 #ifdef ENABLE_FEAT_F4HWN
     if (gSetting_set_ptt_session)
     {
-        if (!GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) && !SerialConfigInProgress() && gPttOnePushCounter == 0)
-        {   // PTT pressed
-            if (++gPttDebounceCounter >= 3)     // 30ms
-            {   // start transmitting
-                boot_counter_10ms   = 0;
+        if ((isPressed && (gPttOnePushCounter == 0 || gPttOnePushCounter == 2)) ||
+            (!isPressed && (gPttOnePushCounter == 1 || gPttOnePushCounter == 3)) ||
+            serialConfigInProgress) 
+        {
+            if (++gPttDebounceCounter >= 3 || (serialConfigInProgress && gPttOnePushCounter > 0))
+            {
                 gPttDebounceCounter = 0;
-                gPttIsPressed       = true;
-                gPttOnePushCounter = 1;
-                ProcessKey(KEY_PTT, true, false);
+                
+                if (gPttOnePushCounter == 0)
+                {   // start transmitting
+                    boot_counter_10ms   = 0;
+                    gPttIsPressed       = true;
+                    gPttOnePushCounter = 1;
+                    ProcessKey(KEY_PTT, true, false);
+                } 
+                else if (gPttOnePushCounter == 3 || serialConfigInProgress)
+                {   // stop transmitting
+                    StopTransmitting();
+                    gPttOnePushCounter = 0;
+                } 
+                else
+                    gPttOnePushCounter++;
             }
-        }
-        else if ((GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) || SerialConfigInProgress()) && gPttOnePushCounter == 1)
-        {   
-            // PTT released or serial comms config in progress
-            if (++gPttDebounceCounter >= 3 || SerialConfigInProgress())     // 30ms
-            {   // stop transmitting
-                gPttOnePushCounter = 2;
-            }
-        }
-        else if (!GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) && !SerialConfigInProgress() && gPttOnePushCounter == 2)
-        {   // PTT pressed again            
-            if (++gPttDebounceCounter >= 3 || SerialConfigInProgress())     // 30ms
-            {   // stop transmitting
-                gPttOnePushCounter = 3;
-            }
-        }
-        else if ((GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) || SerialConfigInProgress()) && gPttOnePushCounter == 3)
-        {   // PTT released or serial comms config in progress
-            if (++gPttDebounceCounter >= 3 || SerialConfigInProgress())     // 30ms
-            {   // stop transmitting
-                ProcessKey(KEY_PTT, false, false);
-                gPttIsPressed = false;
-                if (gKeyReading1 != KEY_INVALID)
-                    gPttWasReleased = true;
-                gPttOnePushCounter = 0;
-                #if defined(ENABLE_FEAT_F4HWN_CTR) || defined(ENABLE_FEAT_F4HWN_INV)
-                ST7565_ContrastAndInv();
-                #endif
-            }
-        }
+        } 
         else
             gPttDebounceCounter = 0;
 
         //gDebug = gPttOnePushCounter;
-    }
-    else
+    } 
+    else 
+#endif
     {
         if (gPttIsPressed)
         {
-            if (GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) || SerialConfigInProgress())
+            if (!isPressed)
             {   // PTT released or serial comms config in progress
-                if (++gPttDebounceCounter >= 3 || SerialConfigInProgress())     // 30ms
+                if (++gPttDebounceCounter >= 3 || serialConfigInProgress)   // 30ms
                 {   // stop transmitting
-                    ProcessKey(KEY_PTT, false, false);
-                    gPttIsPressed = false;
-                    if (gKeyReading1 != KEY_INVALID)
-                        gPttWasReleased = true;
-                    #if defined(ENABLE_FEAT_F4HWN_CTR) || defined(ENABLE_FEAT_F4HWN_INV)
-                    ST7565_ContrastAndInv();
-                    #endif
+                    gPttDebounceCounter = 0;
+                    StopTransmitting();
                 }
-            }
-            else
+            } 
+            else 
                 gPttDebounceCounter = 0;
         }
-        else if (!GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) && !SerialConfigInProgress())
+        else if (isPressed)
         {   // PTT pressed
             if (++gPttDebounceCounter >= 3)     // 30ms
             {   // start transmitting
@@ -1252,37 +1242,8 @@ static void CheckKeys(void)
             }
         }
         else
-            gPttDebounceCounter = 0;        
-    }
-#else
-    if (gPttIsPressed)
-    {
-        if (GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) || SerialConfigInProgress())
-        {   // PTT released or serial comms config in progress
-            if (++gPttDebounceCounter >= 3 || SerialConfigInProgress())     // 30ms
-            {   // stop transmitting
-                ProcessKey(KEY_PTT, false, false);
-                gPttIsPressed = false;
-                if (gKeyReading1 != KEY_INVALID)
-                    gPttWasReleased = true;
-            }
-        }
-        else
             gPttDebounceCounter = 0;
     }
-    else if (!GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) && !SerialConfigInProgress())
-    {   // PTT pressed
-        if (++gPttDebounceCounter >= 3)     // 30ms
-        {   // start transmitting
-            boot_counter_10ms   = 0;
-            gPttDebounceCounter = 0;
-            gPttIsPressed       = true;
-            ProcessKey(KEY_PTT, true, false);
-        }
-    }
-    else
-        gPttDebounceCounter = 0;
-#endif
 
 // --------------------- OTHER KEYS ----------------------------
 
@@ -1399,7 +1360,7 @@ void APP_TimeSlice10ms(void)
 
     #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
     if (gUpdateDisplayCurrent || gUpdateStatusCurrent) {
-        getScreenShot(false);
+        SCREENSHOT_Update(false);
     }
     #endif
 
@@ -1596,9 +1557,11 @@ void APP_TimeSlice500ms(void)
     }
 #endif
 
+    const int m = UI_MENU_GetCurrentMenuId();
+
     if (gBacklightCountdown_500ms > 0 && !gAskToSave && !gCssBackgroundScan
         // don't turn off backlight if user is in backlight menu option
-        && !(gScreenToDisplay == DISPLAY_MENU && (UI_MENU_GetCurrentMenuId() == MENU_ABR || UI_MENU_GetCurrentMenuId() == MENU_ABR_MAX))
+        && !(gScreenToDisplay == DISPLAY_MENU && (m == MENU_ABR || m == MENU_ABR_MAX || m == MENU_ABR_MIN))
         && --gBacklightCountdown_500ms == 0
         && gEeprom.BACKLIGHT_TIME < 61
     ) {
@@ -1631,11 +1594,13 @@ void APP_TimeSlice500ms(void)
         {
             if(gSleepModeCountdown_500ms % 4 == 0)
             {
-                PWM_PLUS0_CH0_COMP = value[gEeprom.BACKLIGHT_MAX] * 4; // Max brightness
+                // PWM_PLUS0_CH0_COMP = value[gEeprom.BACKLIGHT_MAX] * 4; // Max brightness
+                BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MAX);
             }
             else
             {
-                PWM_PLUS0_CH0_COMP = 0;
+                // PWM_PLUS0_CH0_COMP = 0;
+                BACKLIGHT_SetBrightness(0);
             }
         }
     }
@@ -1712,8 +1677,10 @@ void APP_TimeSlice500ms(void)
         if (exit_menu) {
             gMenuCountdown = 0;
 
-            if (gEeprom.BACKLIGHT_TIME == 0) {
-                BACKLIGHT_TurnOff();
+            const int m = UI_MENU_GetCurrentMenuId();
+
+            if (gScreenToDisplay == DISPLAY_MENU && (m == MENU_ABR || m == MENU_ABR_MAX || m == MENU_ABR_MIN)) {
+                BACKLIGHT_TurnOn();
             }
 
             if (gInputBoxIndex > 0 || gDTMF_InputMode) {
@@ -2107,18 +2074,14 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         }
 #endif
     }
+    else if (gScreenToDisplay != DISPLAY_INVALID && (
+            (Key != KEY_SIDE1 && Key != KEY_SIDE2)
 #ifdef ENABLE_FEAT_F4HWN // For F + SIDE1 or F + SIDE2
-    else if (gWasFKeyPressed && (Key == KEY_SIDE1 || Key == KEY_SIDE2)) {
-        ProcessKeysFunctions[gScreenToDisplay](Key, bKeyPressed, bKeyHeld);
-    }
-    else if (Key != KEY_SIDE1 && Key != KEY_SIDE2 && gScreenToDisplay != DISPLAY_INVALID) {
-        ProcessKeysFunctions[gScreenToDisplay](Key, bKeyPressed, bKeyHeld);
-    }
-#else
-    else if (Key != KEY_SIDE1 && Key != KEY_SIDE2 && gScreenToDisplay != DISPLAY_INVALID) {
-        ProcessKeysFunctions[gScreenToDisplay](Key, bKeyPressed, bKeyHeld);
-    }
+            || (gWasFKeyPressed && (Key == KEY_SIDE1 || Key == KEY_SIDE2))
 #endif
+    )) {
+        ProcessKeysFunctions[gScreenToDisplay](Key, bKeyPressed, bKeyHeld);
+    }
     else if (!SCANNER_IsScanning()
 #ifdef ENABLE_AIRCOPY
             && gScreenToDisplay != DISPLAY_AIRCOPY
@@ -2173,7 +2136,7 @@ Skip:
     }
 
     if (gRequestSaveChannel > 0) { // TODO: remove the gRequestSaveChannel, why use global variable for that??
-        if ((!bKeyHeld && !bKeyPressed) || UI_MENU_GetCurrentMenuId())
+        if ((!bKeyHeld && !bKeyPressed) || (UI_MENU_GetCurrentMenuId() != 0 && gScreenToDisplay == DISPLAY_MENU) || gScreenToDisplay == DISPLAY_SCANNER)
         {
             SETTINGS_SaveChannel(gTxVfo->CHANNEL_SAVE, gEeprom.TX_VFO, gTxVfo, gRequestSaveChannel);
 

--- a/app/app.c
+++ b/app/app.c
@@ -1407,8 +1407,7 @@ void APP_TimeSlice10ms(void)
                 if (gAlarmState == ALARM_STATE_TXALARM) {
                     gAlarmState = ALARM_STATE_SITE_ALARM;
 
-                    if(gEeprom.TAIL_TONE_ELIMINATION)
-                        RADIO_SendCssTail();
+                    RADIO_SendCssTail();
                     BK4819_SetupPowerAmplifier(0, 0);
                     BK4819_ToggleGpioOut(BK4819_GPIO1_PIN29_PA_ENABLE, false);
                     BK4819_Enable_AfDac_DiscMode_TxDsp();
@@ -1479,10 +1478,10 @@ void cancelUserInputModes(void)
 
     if (gWasFKeyPressed || gKeyInputCountdown > 0 || gInputBoxIndex > 0)
     {
-        gWasFKeyPressed     = false;
+        HideFKeyIcon();
+
         gInputBoxIndex      = 0;
         gKeyInputCountdown  = 0;
-        gUpdateStatus       = true;
         gUpdateDisplay      = true;
     }
 }
@@ -1698,13 +1697,12 @@ void APP_TimeSlice500ms(void)
 */
             DTMF_clear_input_box();
 
-            gWasFKeyPressed  = false;
+            HideFKeyIcon();
             gInputBoxIndex   = 0;
 
             gAskToSave       = false;
             gAskToDelete     = false;
 
-            gUpdateStatus    = true;
             gUpdateDisplay   = true;
 
             GUI_DisplayType_t disp = DISPLAY_INVALID;
@@ -1996,8 +1994,7 @@ static void ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
     if (gWasFKeyPressed && (Key == KEY_PTT || Key == KEY_EXIT || Key == KEY_SIDE1 || Key == KEY_SIDE2)) { 
 #endif
         // cancel the F-key
-        gWasFKeyPressed = false;
-        gUpdateStatus   = true;
+        HideFKeyIcon();
     }
 
     if (bFlag) {

--- a/app/breakout.c
+++ b/app/breakout.c
@@ -23,7 +23,7 @@
 static uint32_t randSeed = 1;
 static uint8_t blockAnim = 0;
 
-bool isInitialized = false;
+static bool isInitialized = false;
 bool isPaused = false;
 bool isBeep = false;
 
@@ -36,7 +36,7 @@ int16_t ballCount = BALL_NUMBER;
 
 char str[12];
 
-KeyboardState kbd = {KEY_INVALID, KEY_INVALID, 0};
+static KeyboardState kbd = {KEY_INVALID, KEY_INVALID, 0};
 
 Brick brick[BRICK_NUMBER];
 Racket racket;
@@ -421,37 +421,30 @@ bool HandleUserInput()
     
     // Get the current key
     kbd.current = GetKey();
-    
-    // Detect valid key press continuation (same key still pressed)
-    if (kbd.current != KEY_INVALID && kbd.current == kbd.prev)
-    {
-        kbd.counter = 1;
-    }
-    else
-    {
-        kbd.counter = 0;
-    }
-    
-    // Process the key if counter indicates it should be handled
-    if (kbd.counter == 1)
+
+    if (kbd.current == KEY_INVALID)
+        return true;
+
+    // Movement keys: dispatch on every tick while held
+    if (kbd.current == KEY_UP   || kbd.current == KEY_DOWN ||
+        kbd.current == KEY_4    || kbd.current == KEY_0)
     {
         OnKeyDown(kbd.current);
-        
-        // Special handling for MENU key
-        if(kbd.current == KEY_MENU)
-        {
-            kbd.counter = 0;
-            SYSTEM_DelayMs(250);
-        }
+        return true;
     }
-    
+
+    // Action keys (MENU, EXIT): dispatch only on rising edge
+    if (kbd.current != kbd.prev)
+    {
+        OnKeyDown(kbd.current);
+    }
+
     return true;
 }
 
 // Tick
 static void Tick()
 {
-    HandleUserInput();
     HandleUserInput();
 }
 
@@ -482,11 +475,6 @@ void APP_RunBreakout(void) {
                 if(swap == 0)
                 {
                     blockAnim = (blockAnim + 1) % 4;
-
-                    // For screenshot
-                    #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-                        getScreenShot(false);
-                    #endif
                 }
                 
                 swap = (swap + 1) % 4;
@@ -509,5 +497,12 @@ void APP_RunBreakout(void) {
 
             ST7565_BlitStatusLine();  // Blank status line
             ST7565_BlitFullScreen();
+
+            #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
+                if(isPaused || swap == 0)
+                {
+                    SCREENSHOT_Update(false);
+                }
+            #endif
         }
 }

--- a/app/chFrScanner.c
+++ b/app/chFrScanner.c
@@ -37,6 +37,15 @@ uint8_t             initialCROSS_BAND_RX_TX;
 static void NextFreqChannel(void);
 static void NextMemChannel(void);
 
+#if defined(ENABLE_FEAT_F4HWN_RESUME_STATE) || defined(ENABLE_SCAN_RANGES)
+    void CHFRSCANNER_ScanRange(void) {
+        gScanRangeStart = gScanRangeStart ? 0 : gTxVfo->pRX->Frequency;
+        gScanRangeStop = gEeprom.VfoInfo[!gEeprom.TX_VFO].freq_config_RX.Frequency;
+        if(gScanRangeStart > gScanRangeStop)
+            SWAP(gScanRangeStart, gScanRangeStop);
+    }
+#endif
+
 void CHFRSCANNER_Start(const bool storeBackupSettings, const int8_t scan_direction)
 {
     if (storeBackupSettings) {

--- a/app/chFrScanner.h
+++ b/app/chFrScanner.h
@@ -20,6 +20,10 @@ void CHFRSCANNER_Stop(void);
 void CHFRSCANNER_Start(const bool storeBackupSettings, const int8_t scan_direction);
 void CHFRSCANNER_ContinueScanning(void);
 
+#if defined(ENABLE_FEAT_F4HWN_RESUME_STATE) || defined(ENABLE_SCAN_RANGES)
+    void CHFRSCANNER_ScanRange(void);
+#endif
+
 #ifdef ENABLE_FEAT_F4HWN
     extern uint32_t lastFoundFrqOrChan;
     extern uint32_t lastFoundFrqOrChanOld;

--- a/app/common.c
+++ b/app/common.c
@@ -3,6 +3,7 @@
 #include "functions.h"
 #include "misc.h"
 #include "settings.h"
+#include "ui/inputbox.h"
 #include "ui/ui.h"
 
 void COMMON_KeypadLockToggle() 
@@ -29,6 +30,11 @@ void COMMON_SwitchVFOs()
 #endif
     gEeprom.TX_VFO ^= 1;
 
+    if (gInputBoxIndex > 0) {
+        gInputBoxIndex = 0;
+        gHasVfoBackup = false;
+    }
+
     if (gEeprom.CROSS_BAND_RX_TX != CROSS_BAND_OFF)
         gEeprom.CROSS_BAND_RX_TX = gEeprom.TX_VFO + 1;
     if (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF)
@@ -49,6 +55,11 @@ void COMMON_SwitchVFOMode()
     if (gEeprom.VFO_OPEN)
 #endif
     {
+        if (gInputBoxIndex > 0) {
+            gInputBoxIndex = 0;
+            gHasVfoBackup = false;
+        }
+
         if (IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE))
         {   // swap to frequency mode
             gEeprom.ScreenChannel[gEeprom.TX_VFO] = gEeprom.FreqChannel[gEeprom.TX_VFO];

--- a/app/flashlight.c
+++ b/app/flashlight.c
@@ -48,20 +48,29 @@
 
     void ACTION_FlashLight(void)
     {
-        switch (gFlashLightState) {
-            case FLASHLIGHT_OFF:
-                gFlashLightState++;
-                GPIO_SetBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
-                break;
-            case FLASHLIGHT_ON:
-            case FLASHLIGHT_BLINK:
-                gFlashLightState++;
-                break;
-            case FLASHLIGHT_SOS:
-            default:
-                gFlashLightState = 0;
-                GPIO_ClearBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
+        // switch (gFlashLightState) {
+        //     case FLASHLIGHT_OFF:
+        //         gFlashLightState++;
+        //         GPIO_SetBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
+        //         break;
+        //     case FLASHLIGHT_ON:
+        //     case FLASHLIGHT_BLINK:
+        //         gFlashLightState++;
+        //         break;
+        //     case FLASHLIGHT_SOS:
+        //     default:
+        //         gFlashLightState = 0;
+        //         GPIO_ClearBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
+        // }
+
+        if(gFlashLightState == FLASHLIGHT_OFF) {
+            GPIO_SetBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
         }
+        else if (gFlashLightState == FLASHLIGHT_SOS) {
+            GPIO_ClearBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
+        }
+
+        gFlashLightState = (gFlashLightState + 1) % 4;
     }
 #else
     void ACTION_FlashLight(void)

--- a/app/fm.c
+++ b/app/fm.c
@@ -32,10 +32,6 @@
 #include "ui/inputbox.h"
 #include "ui/ui.h"
 
-#ifndef ARRAY_SIZE
-    #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-#endif
-
 uint16_t          gFM_Channels[20];
 bool              gFmRadioMode;
 uint8_t           gFmRadioCountdown_500ms;
@@ -129,6 +125,18 @@ void FM_EraseChannels(void)
     memset(gFM_Channels, 0xFF, sizeof(gFM_Channels));
 }
 
+uint16_t FM_WrapFrequency(uint16_t Frequency) {
+    const uint16_t freqLoLimit = BK1080_GetFreqLoLimit(gEeprom.FM_Band);
+    const uint16_t freqHiLimit = BK1080_GetFreqHiLimit(gEeprom.FM_Band);
+
+    if (Frequency < freqLoLimit)
+        return freqHiLimit;
+    else if (Frequency > freqHiLimit)
+        return freqLoLimit;
+
+    return Frequency;
+}
+
 void FM_Tune(uint16_t Frequency, int8_t Step, bool bFlag)
 {
     AUDIO_AudioPathOff();
@@ -145,10 +153,7 @@ void FM_Tune(uint16_t Frequency, int8_t Step, bool bFlag)
 
     if (!bFlag) {
         Frequency += Step;
-        if (Frequency < BK1080_GetFreqLoLimit(gEeprom.FM_Band))
-            Frequency = BK1080_GetFreqHiLimit(gEeprom.FM_Band);
-        else if (Frequency > BK1080_GetFreqHiLimit(gEeprom.FM_Band))
-            Frequency = BK1080_GetFreqLoLimit(gEeprom.FM_Band);
+        Frequency = FM_WrapFrequency(Frequency);
 
         gEeprom.FM_FrequencyPlaying = Frequency;
     }
@@ -182,65 +187,45 @@ void FM_PlayAndUpdate(void)
 
 int FM_CheckFrequencyLock(uint16_t Frequency, uint16_t LowerLimit)
 {
-    int ret = -1;
-
-    const uint16_t Test2 = BK1080_ReadRegister(BK1080_REG_07);
-
-    // This is supposed to be a signed value, but above function is unsigned
+    const uint16_t Test2     = BK1080_ReadRegister(BK1080_REG_07);
     const uint16_t Deviation = BK1080_REG_07_GET_FREQD(Test2);
 
-    if (BK1080_REG_07_GET_SNR(Test2) <= 2) {
-        BK1080_FrequencyDeviation = Deviation;
-        BK1080_BaseFrequency      = Frequency;
+    // Helper macro to update globals and return
+    #define RETURN(val) \
+        do { \
+            BK1080_FrequencyDeviation = Deviation; \
+            BK1080_BaseFrequency      = Frequency; \
+            return (val); \
+        } while (0)
 
-        return ret;
-    }
+    if (BK1080_REG_07_GET_SNR(Test2) <= 2)
+        RETURN(-1);
 
     const uint16_t Status = BK1080_ReadRegister(BK1080_REG_10);
+    if ((Status & BK1080_REG_10_MASK_AFCRL) != BK1080_REG_10_AFCRL_NOT_RAILED ||
+        BK1080_REG_10_GET_RSSI(Status) < 10)
+        RETURN(-1);
 
-    if ((Status & BK1080_REG_10_MASK_AFCRL) != BK1080_REG_10_AFCRL_NOT_RAILED || BK1080_REG_10_GET_RSSI(Status) < 10) {
-        BK1080_FrequencyDeviation = Deviation;
-        BK1080_BaseFrequency      = Frequency;
+    if (Deviation >= 280 && Deviation <= 3815)
+        RETURN(-1);
 
-        return ret;
-    }
-
-    //if (Deviation > -281 && Deviation < 280)
-    if (Deviation >= 280 && Deviation <= 3815) {
-        BK1080_FrequencyDeviation = Deviation;
-        BK1080_BaseFrequency      = Frequency;
-
-        return ret;
-    }
-
-    // not BLE(less than or equal)
+    // Scanning upward: previous deviation was negative (bit 11 set) or near zero
     if (Frequency > LowerLimit && (Frequency - BK1080_BaseFrequency) == 1) {
-        if (BK1080_FrequencyDeviation & 0x800 || (BK1080_FrequencyDeviation < 20))
-        {
-            BK1080_FrequencyDeviation = Deviation;
-            BK1080_BaseFrequency      = Frequency;
-
-            return ret;
-        }
+        if (BK1080_FrequencyDeviation & 0x800 || BK1080_FrequencyDeviation < 20)
+            RETURN(-1);
     }
 
-    // not BLT(less than)
-
+    // Scanning downward: previous deviation was positive or saturated high
     if (Frequency >= LowerLimit && (BK1080_BaseFrequency - Frequency) == 1) {
-        if ((BK1080_FrequencyDeviation & 0x800) == 0 || (BK1080_FrequencyDeviation > 4075))
-        {
-            BK1080_FrequencyDeviation = Deviation;
-            BK1080_BaseFrequency      = Frequency;
-
-            return ret;
-        }
+        if ((BK1080_FrequencyDeviation & 0x800) == 0 || BK1080_FrequencyDeviation > 4075)
+            RETURN(-1);
     }
 
-    ret = 0;
+    #undef RETURN
+
     BK1080_FrequencyDeviation = Deviation;
     BK1080_BaseFrequency      = Frequency;
-
-    return ret;
+    return 0;
 }
 
 static void Key_DIGITS(KEY_Code_t Key, uint8_t state)
@@ -376,7 +361,7 @@ static void Key_FUNC(KEY_Code_t Key, uint8_t state)
                 else
                     gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
                 break;
-            
+
             case KEY_8:
                 ACTION_BackLightOnDemand();
                 break;
@@ -529,10 +514,7 @@ static void Key_UP_DOWN(uint8_t state, int8_t Step)
     else {
         uint16_t Frequency = gEeprom.FM_SelectedFrequency + Step;
 
-        if (Frequency < BK1080_GetFreqLoLimit(gEeprom.FM_Band))
-            Frequency = BK1080_GetFreqHiLimit(gEeprom.FM_Band);
-        else if (Frequency > BK1080_GetFreqHiLimit(gEeprom.FM_Band))
-            Frequency = BK1080_GetFreqLoLimit(gEeprom.FM_Band);
+        Frequency = FM_WrapFrequency(Frequency);
 
         gEeprom.FM_FrequencyPlaying  = Frequency;
         gEeprom.FM_SelectedFrequency = gEeprom.FM_FrequencyPlaying;
@@ -560,12 +542,21 @@ void FM_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         case KEY_MENU:
             Key_MENU(state);
             break;
-        case KEY_UP:
-            Key_UP_DOWN(state, 1);
-            break;
-        case KEY_DOWN:
-            Key_UP_DOWN(state, -1);
-            break;;
+
+        #if defined(ENABLE_FMRADIO) && defined(ENABLE_SPECTRUM) // The size of the Basic version is increasing, while the others are decreasing, so that's why...
+            case KEY_UP:
+                Key_UP_DOWN(state, 1);
+                break;
+            case KEY_DOWN:
+                Key_UP_DOWN(state, -1);
+                break;
+        #else
+            case KEY_UP:
+            case KEY_DOWN:
+                Key_UP_DOWN(state, Key == KEY_UP ? 1 : -1);
+                break;
+        #endif
+        
         case KEY_EXIT:
             Key_EXIT(state);
             break;

--- a/app/fm.c
+++ b/app/fm.c
@@ -332,8 +332,7 @@ static void Key_FUNC(KEY_Code_t Key, uint8_t state)
         bool autoScan = gWasFKeyPressed || (state == BUTTON_EVENT_HELD);
 
         gBeepToPlay           = BEEP_1KHZ_60MS_OPTIONAL;
-        gWasFKeyPressed       = false;
-        gUpdateStatus         = true;
+        HideFKeyIcon();
         gRequestDisplayScreen = DISPLAY_FM;
 
         switch (Key) {

--- a/app/main.c
+++ b/app/main.c
@@ -51,7 +51,6 @@
 static VFO_Info_t gVfoBackup;
 static uint16_t   gScreenChannelBackup = 0;
 static uint16_t   gFreqChannelBackup = 0;
-static bool       gHasVfoBackup = false;
 
 static void toggle_chan_scanlist(void)
 {   // toggle the selected channels scanlist setting
@@ -552,6 +551,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
                 }
 
                 gInputBoxIndex = 0;
+                gHasVfoBackup = false;
 
                 uint8_t Channel = (gInputBox[0] * 10) + gInputBox[1];
                 if (Channel >= 1 && Channel <= ARRAY_SIZE(NoaaFrequencyTable)) {
@@ -613,8 +613,7 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
     if (bKeyHeld) { // exit key held down
         if (bKeyPressed) {
             if (gInputBoxIndex > 0 || gDTMF_InputBox_Index > 0 || gDTMF_InputMode)
-            {   // cancel key input mode (channel/frequency entry)
-
+            {
                 // Restore full VFO state on long press EXIT
                 if (gHasVfoBackup) {
                     const uint8_t Vfo = gEeprom.TX_VFO;
@@ -634,12 +633,7 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
                     gHasVfoBackup = false;
                 }
 
-                gDTMF_InputMode       = false;
-                gDTMF_InputBox_Index  = 0;
-                memset(gDTMF_String, 0, sizeof(gDTMF_String));
-                gInputBoxIndex        = 0;
                 gRequestDisplayScreen = DISPLAY_MAIN;
-                gBeepToPlay           = BEEP_1KHZ_60MS_OPTIONAL;
             }
         }
 
@@ -900,8 +894,10 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
     uint8_t Channel = gEeprom.ScreenChannel[gEeprom.TX_VFO];
 
     if (bKeyHeld || !bKeyPressed) { // key held or released
-        if (gInputBoxIndex > 0)
+        if (gInputBoxIndex > 0) {
             gInputBoxIndex = 0;
+            gHasVfoBackup = false;
+        }
 
         if (!bKeyPressed) {
             if (!bKeyHeld || IS_FREQ_CHANNEL(Channel))

--- a/app/main.c
+++ b/app/main.c
@@ -52,6 +52,26 @@ static VFO_Info_t gVfoBackup;
 static uint16_t   gScreenChannelBackup = 0;
 static uint16_t   gFreqChannelBackup = 0;
 
+static void VFO_RestoreBackup(void) {
+    if (gHasVfoBackup) {
+        const uint8_t Vfo = gEeprom.TX_VFO;
+
+        // Restore indices
+        gEeprom.ScreenChannel[Vfo] = gScreenChannelBackup;
+        gEeprom.FreqChannel[Vfo] = gFreqChannelBackup;
+
+        // Restore full VFO
+        memcpy(gTxVfo, &gVfoBackup, sizeof(VFO_Info_t));
+
+        // Save and apply
+        SETTINGS_SaveVfoIndices();
+        RADIO_ConfigureSquelchAndOutputPower(gTxVfo);
+        RADIO_SetupRegisters(true);
+
+        gHasVfoBackup = false;
+    }
+}
+
 static void toggle_chan_scanlist(void)
 {   // toggle the selected channels scanlist setting
 
@@ -95,8 +115,7 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
 
 #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
     if(gEeprom.MENU_LOCK == true && Key != 2) {
-        gUpdateStatus   = true;
-        gWasFKeyPressed = false;
+        HideFKeyIcon();
 
         return;
     }
@@ -116,8 +135,7 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
 
         case KEY_1:
             if (!IS_FREQ_CHANNEL(gTxVfo->CHANNEL_SAVE)) {
-                gWasFKeyPressed = false;
-                gUpdateStatus   = true;
+                HideFKeyIcon();
 
 #ifdef ENABLE_COPY_CHAN_TO_VFO
                 if (!gEeprom.VFO_OPEN || gCssBackgroundScan) {
@@ -199,11 +217,10 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
             break;
 
         case KEY_4:
-            gWasFKeyPressed          = false;
+            HideFKeyIcon();
 
             gBackup_CROSS_BAND_RX_TX  = gEeprom.CROSS_BAND_RX_TX;
-            gEeprom.CROSS_BAND_RX_TX = CROSS_BAND_OFF;
-            gUpdateStatus            = true;        
+            gEeprom.CROSS_BAND_RX_TX = CROSS_BAND_OFF;      
 
             SCANNER_Start(false);
             gRequestDisplayScreen = DISPLAY_SCANNER;
@@ -307,8 +324,7 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
 #endif
 
         default:
-            gUpdateStatus   = true;
-            gWasFKeyPressed = false;
+            HideFKeyIcon();
 
             if (beep)
                 gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
@@ -398,8 +414,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
                     gRequestDisplayScreen = DISPLAY_MAIN;
                 }
 
-                gWasFKeyPressed = false;
-                gUpdateStatus   = true;
+                HideFKeyIcon();
 
                 processFKeyFunction(Key, true);
             }
@@ -573,8 +588,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         return;
     }
 
-    gWasFKeyPressed = false;
-    gUpdateStatus   = true;
+    HideFKeyIcon();
 
     #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
         if(gEeprom.MENU_LOCK == true && Key != 2) {
@@ -612,29 +626,10 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 
     if (bKeyHeld) { // exit key held down
         if (bKeyPressed) {
-            if (gInputBoxIndex > 0 || gDTMF_InputBox_Index > 0 || gDTMF_InputMode)
-            {
-                // Restore full VFO state on long press EXIT
-                if (gHasVfoBackup) {
-                    const uint8_t Vfo = gEeprom.TX_VFO;
+            // Restore full VFO state on long press EXIT
+            VFO_RestoreBackup();
 
-                    // Restore indices
-                    gEeprom.ScreenChannel[Vfo] = gScreenChannelBackup;
-                    gEeprom.FreqChannel[Vfo] = gFreqChannelBackup;
-
-                    // Restore full VFO
-                    memcpy(gTxVfo, &gVfoBackup, sizeof(VFO_Info_t));
-
-                    // Save and apply
-                    SETTINGS_SaveVfoIndices();
-                    RADIO_ConfigureSquelchAndOutputPower(gTxVfo);
-                    RADIO_SetupRegisters(true);
-
-                    gHasVfoBackup = false;
-                }
-
-                gRequestDisplayScreen = DISPLAY_MAIN;
-            }
+            gRequestDisplayScreen = DISPLAY_MAIN;
         }
 
         return;
@@ -659,23 +654,8 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
             gInputBox[--gInputBoxIndex] = 10;
 
             // Restore full VFO state when back to 0
-            if (gInputBoxIndex == 0 && gHasVfoBackup) {
-                const uint8_t Vfo = gEeprom.TX_VFO;
-
-                // Restore indices
-                gEeprom.ScreenChannel[Vfo] = gScreenChannelBackup;
-                gEeprom.FreqChannel[Vfo] = gFreqChannelBackup;
-
-                // Restore full VFO
-                memcpy(gTxVfo, &gVfoBackup, sizeof(VFO_Info_t));
-
-                // Save and apply
-                SETTINGS_SaveVfoIndices();
-                RADIO_ConfigureSquelchAndOutputPower(gTxVfo);
-                RADIO_SetupRegisters(true);
-
-                gHasVfoBackup = false;
-            }
+            if (gInputBoxIndex == 0)
+                VFO_RestoreBackup();
 
             gKeyInputCountdown = key_input_timeout_500ms;
             channelMoveSwitch();
@@ -765,8 +745,7 @@ static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
 
             #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
                 if(gEeprom.MENU_LOCK == true) {
-                    gUpdateStatus   = true;
-                    gWasFKeyPressed = false;
+                    HideFKeyIcon();
 
                     return;
                 }
@@ -802,8 +781,7 @@ static void MAIN_Key_STAR(bool bKeyPressed, bool bKeyHeld)
 
     #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
         if(gEeprom.MENU_LOCK == true) {
-            gUpdateStatus   = true;
-            gWasFKeyPressed = false;
+            HideFKeyIcon();
 
             return; // prevent F function if MENU LOCK is true
         }

--- a/app/main.c
+++ b/app/main.c
@@ -47,6 +47,12 @@
 #include "ui/ui.h"
 #include <stdlib.h>
 
+// Full VFO backup for restore on EXIT
+static VFO_Info_t gVfoBackup;
+static uint16_t   gScreenChannelBackup = 0;
+static uint16_t   gFreqChannelBackup = 0;
+static bool       gHasVfoBackup = false;
+
 static void toggle_chan_scanlist(void)
 {   // toggle the selected channels scanlist setting
 
@@ -55,10 +61,7 @@ static void toggle_chan_scanlist(void)
 
     if(!IS_MR_CHANNEL(gTxVfo->CHANNEL_SAVE)) {
 #ifdef ENABLE_SCAN_RANGES
-        gScanRangeStart = gScanRangeStart ? 0 : gTxVfo->pRX->Frequency;
-        gScanRangeStop = gEeprom.VfoInfo[!gEeprom.TX_VFO].freq_config_RX.Frequency;
-        if(gScanRangeStart > gScanRangeStop)
-            SWAP(gScanRangeStart, gScanRangeStop);
+        CHFRSCANNER_ScanRange();
 #endif
         return;
     }
@@ -88,16 +91,15 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
 {
     uint8_t Vfo = gEeprom.TX_VFO;
 
-#ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-    if(gEeprom.MENU_LOCK == true) {
-        if(Key == 2) { // Enable A/B only
-            gVfoConfigureMode     = VFO_CONFIGURE;
-            COMMON_SwitchVFOs();
-            if (beep)
-                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
-        }
+    if (beep)
+        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
-        return; // prevent F function if MENU LOCK is true
+#ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
+    if(gEeprom.MENU_LOCK == true && Key != 2) {
+        gUpdateStatus   = true;
+        gWasFKeyPressed = false;
+
+        return;
     }
 #endif
 
@@ -117,7 +119,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
             if (!IS_FREQ_CHANNEL(gTxVfo->CHANNEL_SAVE)) {
                 gWasFKeyPressed = false;
                 gUpdateStatus   = true;
-                gBeepToPlay     = BEEP_1KHZ_60MS_OPTIONAL;
 
 #ifdef ENABLE_COPY_CHAN_TO_VFO
                 if (!gEeprom.VFO_OPEN || gCssBackgroundScan) {
@@ -181,9 +182,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
 
             gRequestDisplayScreen      = DISPLAY_MAIN;
 
-            if (beep)
-                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
-
             break;
 
         case KEY_2:
@@ -191,8 +189,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
                 gVfoConfigureMode     = VFO_CONFIGURE;
             #endif
             COMMON_SwitchVFOs();
-            if (beep)
-                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
             break;
 
         case KEY_3:
@@ -200,8 +196,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
                 gVfoConfigureMode     = VFO_CONFIGURE;
             #endif
             COMMON_SwitchVFOMode();
-            if (beep)
-                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
             break;
 
@@ -211,8 +205,6 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
             gBackup_CROSS_BAND_RX_TX  = gEeprom.CROSS_BAND_RX_TX;
             gEeprom.CROSS_BAND_RX_TX = CROSS_BAND_OFF;
             gUpdateStatus            = true;        
-            if (beep)
-                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
             SCANNER_Start(false);
             gRequestDisplayScreen = DISPLAY_SCANNER;
@@ -280,42 +272,39 @@ static void processFKeyFunction(const KEY_Code_t Key, const bool beep)
 
 #ifdef ENABLE_FEAT_F4HWN // Set Squelch F + UP or Down and Step F + SIDE1 or F + SIDE2
         case KEY_UP:
-            gEeprom.SQUELCH_LEVEL = (gEeprom.SQUELCH_LEVEL < 9) ? gEeprom.SQUELCH_LEVEL + 1: 9;
-            gVfoConfigureMode     = VFO_CONFIGURE;
-            gWasFKeyPressed = false;
-            break;
         case KEY_DOWN:
-            gEeprom.SQUELCH_LEVEL = (gEeprom.SQUELCH_LEVEL > 0) ? gEeprom.SQUELCH_LEVEL - 1: 0;
-            gVfoConfigureMode     = VFO_CONFIGURE;
-            gWasFKeyPressed = false;
-            break;
+            {
+                // Adjust squelch: UP increments, DOWN decrements
+                if (Key == KEY_UP) {
+                    gEeprom.SQUELCH_LEVEL = (gEeprom.SQUELCH_LEVEL < 9) ? gEeprom.SQUELCH_LEVEL + 1 : 9;
+                } else {
+                    gEeprom.SQUELCH_LEVEL = (gEeprom.SQUELCH_LEVEL > 0) ? gEeprom.SQUELCH_LEVEL - 1 : 0;
+                }
+                gVfoConfigureMode = VFO_CONFIGURE;
+                gWasFKeyPressed = false;
 
+                break;
+            }
         case KEY_SIDE1:
-            uint8_t a = FREQUENCY_GetSortedIdxFromStepIdx(gTxVfo->STEP_SETTING);
-            if (a < STEP_N_ELEM - 1)
-            {
-                gTxVfo->STEP_SETTING = FREQUENCY_GetStepIdxFromSortedIdx(a + 1);
-            }
-            if (IS_FREQ_CHANNEL(gTxVfo->CHANNEL_SAVE))
-            {
-                gRequestSaveChannel = 1;
-            }
-            gVfoConfigureMode     = VFO_CONFIGURE;
-            gWasFKeyPressed = false;
-            break;
         case KEY_SIDE2:
-            uint8_t b = FREQUENCY_GetSortedIdxFromStepIdx(gTxVfo->STEP_SETTING);
-            if (b > 0)
             {
-                gTxVfo->STEP_SETTING = FREQUENCY_GetStepIdxFromSortedIdx(b - 1);
+                bool isKeySide1 = (Key == KEY_SIDE1);
+                uint8_t idx = FREQUENCY_GetSortedIdxFromStepIdx(gTxVfo->STEP_SETTING);
+
+                if ((isKeySide1 && idx < STEP_N_ELEM - 1) || (!isKeySide1 && idx > 0)) 
+                {
+                    gTxVfo->STEP_SETTING = FREQUENCY_GetStepIdxFromSortedIdx(idx + (isKeySide1 ? 1 : -1));
+                    
+                    if (IS_FREQ_CHANNEL(gTxVfo->CHANNEL_SAVE)) {
+                        gRequestSaveChannel = 1;
+                    }
+                    gVfoConfigureMode = VFO_CONFIGURE;
+                }
+                
+                gWasFKeyPressed = false;
+
+                break;
             }
-            if (IS_FREQ_CHANNEL(gTxVfo->CHANNEL_SAVE))
-            {
-                gRequestSaveChannel = 1;
-            }
-            gVfoConfigureMode     = VFO_CONFIGURE;
-            gWasFKeyPressed = false;
-            break;
 #endif
 
         default:
@@ -396,6 +385,7 @@ void channelMoveSwitch(void) {
         }
 
         channelMove(Channel - 1);
+        SETTINGS_SaveVfoIndices();
     }
 }
 
@@ -441,6 +431,15 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         }
 
         const uint8_t Vfo = gEeprom.TX_VFO;
+
+        // Save full VFO state BEFORE first digit
+        if (gInputBoxIndex == 0 && IS_FREQ_CHANNEL(gTxVfo->CHANNEL_SAVE)) {
+            memcpy(&gVfoBackup, gTxVfo, sizeof(VFO_Info_t));
+            gScreenChannelBackup = gEeprom.ScreenChannel[Vfo];
+            gFreqChannelBackup = gEeprom.FreqChannel[Vfo];
+            gHasVfoBackup = true;
+        }
+
         INPUTBOX_Append(Key);
         gKeyInputCountdown = key_input_timeout_500ms;
 
@@ -478,7 +477,13 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
                 return;
             }
             
-            gKeyInputCountdown = (gInputBoxIndex == totalDigits) ? (key_input_timeout_500ms / 16) : (key_input_timeout_500ms / 3);
+            gKeyInputCountdown = (gInputBoxIndex >= totalDigits) ? (key_input_timeout_500ms / 16) : (key_input_timeout_500ms / 3);
+
+            if (gInputBoxIndex > totalDigits) {
+                gInputBoxIndex =  totalDigits;
+
+                return;
+            }
 
             const char *inputStr = INPUTBOX_GetAscii();
             uint8_t inputLength = gInputBoxIndex;
@@ -571,6 +576,12 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
     gWasFKeyPressed = false;
     gUpdateStatus   = true;
 
+    #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
+        if(gEeprom.MENU_LOCK == true && Key != 2) {
+            return;
+        }
+    #endif
+
     if(Key == 8)
     {
         ACTION_BackLightOnDemand();
@@ -603,6 +614,26 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
         if (bKeyPressed) {
             if (gInputBoxIndex > 0 || gDTMF_InputBox_Index > 0 || gDTMF_InputMode)
             {   // cancel key input mode (channel/frequency entry)
+
+                // Restore full VFO state on long press EXIT
+                if (gHasVfoBackup) {
+                    const uint8_t Vfo = gEeprom.TX_VFO;
+
+                    // Restore indices
+                    gEeprom.ScreenChannel[Vfo] = gScreenChannelBackup;
+                    gEeprom.FreqChannel[Vfo] = gFreqChannelBackup;
+
+                    // Restore full VFO
+                    memcpy(gTxVfo, &gVfoBackup, sizeof(VFO_Info_t));
+
+                    // Save and apply
+                    SETTINGS_SaveVfoIndices();
+                    RADIO_ConfigureSquelchAndOutputPower(gTxVfo);
+                    RADIO_SetupRegisters(true);
+
+                    gHasVfoBackup = false;
+                }
+
                 gDTMF_InputMode       = false;
                 gDTMF_InputBox_Index  = 0;
                 memset(gDTMF_String, 0, sizeof(gDTMF_String));
@@ -631,10 +662,28 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
         if (gScanStateDir == SCAN_OFF) {
             if (gInputBoxIndex == 0)
                 return;
-
             gInputBox[--gInputBoxIndex] = 10;
-            gKeyInputCountdown = key_input_timeout_500ms;
 
+            // Restore full VFO state when back to 0
+            if (gInputBoxIndex == 0 && gHasVfoBackup) {
+                const uint8_t Vfo = gEeprom.TX_VFO;
+
+                // Restore indices
+                gEeprom.ScreenChannel[Vfo] = gScreenChannelBackup;
+                gEeprom.FreqChannel[Vfo] = gFreqChannelBackup;
+
+                // Restore full VFO
+                memcpy(gTxVfo, &gVfoBackup, sizeof(VFO_Info_t));
+
+                // Save and apply
+                SETTINGS_SaveVfoIndices();
+                RADIO_ConfigureSquelchAndOutputPower(gTxVfo);
+                RADIO_SetupRegisters(true);
+
+                gHasVfoBackup = false;
+            }
+
+            gKeyInputCountdown = key_input_timeout_500ms;
             channelMoveSwitch();
 
 #ifdef ENABLE_VOICE
@@ -644,6 +693,7 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
         }
         else {
             gScanKeepResult = false;
+            gInputBoxIndex = 0;
             CHFRSCANNER_Stop();
 
 #ifdef ENABLE_VOICE
@@ -658,6 +708,7 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 #ifdef ENABLE_FMRADIO
     ACTION_FM();
 #endif
+    return;
 }
 
 static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
@@ -696,7 +747,6 @@ static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
                     gRequestDisplayScreen = DISPLAY_MAIN;
                 }
 
-                gWasFKeyPressed = false;
                 gUpdateStatus   = true;
 
                 ACTION_Handle(KEY_MENU, bKeyPressed, bKeyHeld);
@@ -720,17 +770,18 @@ static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
             }
 
             #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-            if(gEeprom.MENU_LOCK == false) {
+                if(gEeprom.MENU_LOCK == true) {
+                    gUpdateStatus   = true;
+                    gWasFKeyPressed = false;
+
+                    return;
+                }
             #endif
 
             gFlagRefreshSetting = true;
             gRequestDisplayScreen = DISPLAY_MENU;
             #ifdef ENABLE_VOICE
                 gAnotherVoiceID   = VOICE_ID_MENU;
-            #endif
-
-            #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-            }
             #endif
         }
         else {
@@ -741,13 +792,6 @@ static void MAIN_Key_MENU(bool bKeyPressed, bool bKeyHeld)
 
 static void MAIN_Key_STAR(bool bKeyPressed, bool bKeyHeld)
 {
-
-#ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-    if(gEeprom.MENU_LOCK == true) {
-        return; // prevent F function if MENU LOCK is true
-    }
-#endif
-
     if (gCurrentFunction == FUNCTION_TRANSMIT)
         return;
     
@@ -756,6 +800,20 @@ static void MAIN_Key_STAR(bool bKeyPressed, bool bKeyHeld)
             gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
         return;
     }
+
+    if (!bKeyHeld && bKeyPressed) { // star key pressed
+        gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;  // beep when key is pressed
+        return;                                 // don't use the key till it's released
+    }
+
+    #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
+        if(gEeprom.MENU_LOCK == true) {
+            gUpdateStatus   = true;
+            gWasFKeyPressed = false;
+
+            return; // prevent F function if MENU LOCK is true
+        }
+    #endif
 
     if (bKeyHeld && !gWasFKeyPressed){ // long press
         if (!bKeyPressed) // released
@@ -779,12 +837,6 @@ static void MAIN_Key_STAR(bool bKeyPressed, bool bKeyHeld)
         gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
         return;
     }
-
-    if (bKeyPressed) { // just pressed
-        return;
-    }
-    
-    // just released
     
     if (!gWasFKeyPressed) // pressed without the F-key
     {   
@@ -797,7 +849,6 @@ static void MAIN_Key_STAR(bool bKeyPressed, bool bKeyHeld)
 #endif      
         )
         {   // start entering a DTMF string
-            gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
             memcpy(gDTMF_InputBox, gDTMF_String, MIN(sizeof(gDTMF_InputBox), sizeof(gDTMF_String) - 1));
             gDTMF_InputBox_Index  = 0;
             gDTMF_InputMode       = true;
@@ -836,15 +887,7 @@ static void MAIN_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 
 #ifdef ENABLE_FEAT_F4HWN // Set Squelch F + UP or Down
     if(gWasFKeyPressed) {
-        switch(Direction)
-        {
-            case 1:
-                processFKeyFunction(KEY_UP, false);
-                break;
-            case -1:
-                processFKeyFunction(KEY_DOWN, false);
-                break;
-        }
+        processFKeyFunction(Direction == 1 ? KEY_UP : KEY_DOWN, true);
         return;
     }
 #endif
@@ -972,10 +1015,8 @@ void MAIN_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
             MAIN_Key_MENU(bKeyPressed, bKeyHeld);
             break;
         case KEY_UP:
-            MAIN_Key_UP_DOWN(bKeyPressed, bKeyHeld, 1);
-            break;
         case KEY_DOWN:
-            MAIN_Key_UP_DOWN(bKeyPressed, bKeyHeld, -1);
+            MAIN_Key_UP_DOWN(bKeyPressed, bKeyHeld, Key == KEY_UP ? 1 : -1);
             break;
         case KEY_EXIT:
             MAIN_Key_EXIT(bKeyPressed, bKeyHeld);

--- a/app/menu.c
+++ b/app/menu.c
@@ -42,10 +42,6 @@
 #include "ui/menu.h"
 #include "ui/ui.h"
 
-#ifndef ARRAY_SIZE
-    #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-#endif
-
 uint8_t gUnlockAllTxConfCnt;
 
 #ifdef ENABLE_F_CAL_MENU
@@ -878,11 +874,11 @@ void MENU_AcceptSetting(void)
         #endif
 
         case MENU_BATCAL:
-        {                                                                // voltages are averages between discharge curves of 1600 and 2200 mAh
+        {                                                                   // voltages are averages between discharge curves of 1600 and 2200 mAh
             // gBatteryCalibration[0] = (520ul * gSubMenuSelection) / 760;  // 5.20V empty, blinking above this value, reduced functionality below
             // gBatteryCalibration[1] = (689ul * gSubMenuSelection) / 760;  // 6.89V,  ~5%, 1 bars above this value
             // gBatteryCalibration[2] = (724ul * gSubMenuSelection) / 760;  // 7.24V, ~17%, 2 bars above this value
-            gBatteryCalibration[3] =          gSubMenuSelection;         // 7.6V,  ~29%, 3 bars above this value
+            gBatteryCalibration[3] =          gSubMenuSelection;            // 7.6V,  ~29%, 3 bars above this value
             // gBatteryCalibration[4] = (771ul * gSubMenuSelection) / 760;  // 7.71V, ~65%, 4 bars above this value
             // gBatteryCalibration[5] = 2300;
             SETTINGS_SaveBatteryCalibration(gBatteryCalibration);
@@ -930,11 +926,11 @@ void MENU_AcceptSetting(void)
         case MENU_SET_EOT:
             gSetting_set_eot = gSubMenuSelection;
             break;
-#ifdef ENABLE_FEAT_F4HWN_CTR
+        #ifdef ENABLE_FEAT_F4HWN_CTR
         case MENU_SET_CTR:
             gSetting_set_ctr = gSubMenuSelection;
             break;
-#endif
+        #endif
         case MENU_SET_INV:
             gSetting_set_inv = gSubMenuSelection;
             break;
@@ -1377,11 +1373,11 @@ void MENU_ShowCurrentSetting(void)
         case MENU_SET_EOT:
             gSubMenuSelection = gSetting_set_eot;
             break;
-#ifdef ENABLE_FEAT_F4HWN_CTR
+        #ifdef ENABLE_FEAT_F4HWN_CTR
         case MENU_SET_CTR:
             gSubMenuSelection = gSetting_set_ctr;
             break;
-#endif
+        #endif
         case MENU_SET_INV:
             gSubMenuSelection = gSetting_set_inv;
             break;
@@ -1522,10 +1518,12 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
         return;
     }
 
-    if (UI_MENU_GetCurrentMenuId() == MENU_MEM_CH ||
-        UI_MENU_GetCurrentMenuId() == MENU_DEL_CH ||
-        UI_MENU_GetCurrentMenuId() == MENU_1_CALL ||
-        UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME)
+    const int m = UI_MENU_GetCurrentMenuId();
+
+    if (m == MENU_MEM_CH ||
+        m == MENU_DEL_CH ||
+        m == MENU_1_CALL ||
+        m == MENU_MEM_NAME)
     {   // enter 3-digit channel number
 
         if (gInputBoxIndex < 3)
@@ -1664,19 +1662,21 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 
     if (!gIsInSubMenu)
     {
+        const int m = UI_MENU_GetCurrentMenuId();
+
         #ifdef ENABLE_VOICE
-            if (UI_MENU_GetCurrentMenuId() != MENU_SCR)
+            if (m != MENU_SCR)
                 gAnotherVoiceID = MenuList[gMenuCursor].voice_id;
         #endif
-        if (UI_MENU_GetCurrentMenuId() == MENU_UPCODE 
-            || UI_MENU_GetCurrentMenuId() == MENU_DWCODE 
+        if (m == MENU_UPCODE 
+            || m == MENU_DWCODE 
 #ifdef ENABLE_DTMF_CALLING 
-            || UI_MENU_GetCurrentMenuId() == MENU_ANI_ID
+            || m == MENU_ANI_ID
 #endif
             )
             return;
         #if 1
-            if (UI_MENU_GetCurrentMenuId() == MENU_DEL_CH || UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME)
+            if (m == MENU_DEL_CH || m == MENU_MEM_NAME)
                 if (!RADIO_CheckValidChannel(gSubMenuSelection, false, 0))
                     return;  // invalid channel
         #endif
@@ -1684,7 +1684,7 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
         gAskForConfirmation = 0;
         gIsInSubMenu        = true;
 
-//      if (UI_MENU_GetCurrentMenuId() != MENU_D_LIST)
+//      if (m != MENU_D_LIST)
         {
             gInputBoxIndex      = 0;
             edit_index          = -1;
@@ -1735,10 +1735,12 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 
     if (gIsInSubMenu)
     {
-        if (UI_MENU_GetCurrentMenuId() == MENU_RESET  ||
-            UI_MENU_GetCurrentMenuId() == MENU_MEM_CH ||
-            UI_MENU_GetCurrentMenuId() == MENU_DEL_CH ||
-            UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME)
+        const int m = UI_MENU_GetCurrentMenuId();
+
+        if (m == MENU_RESET  ||
+            m == MENU_MEM_CH ||
+            m == MENU_DEL_CH ||
+            m == MENU_MEM_NAME)
         {
             switch (gAskForConfirmation)
             {
@@ -1751,7 +1753,7 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 
                     UI_DisplayMenu();
 
-                    if (UI_MENU_GetCurrentMenuId() == MENU_RESET)
+                    if (m == MENU_RESET)
                     {
                         #ifdef ENABLE_VOICE
                             AUDIO_SetVoiceID(0, VOICE_ID_CONFIRM);
@@ -1825,7 +1827,8 @@ static void MENU_Key_STAR(const bool bKeyPressed, const bool bKeyHeld)
         if (gRxVfo->Modulation ==  MODULATION_FM)
     #endif
     {
-        if ((UI_MENU_GetCurrentMenuId() == MENU_R_CTCS || UI_MENU_GetCurrentMenuId() == MENU_R_DCS) && gIsInSubMenu)
+        const int m = UI_MENU_GetCurrentMenuId();
+        if ((m == MENU_R_CTCS || m == MENU_R_DCS) && gIsInSubMenu)
         {   // scan CTCSS or DCS to find the tone/code of the incoming signal
             if (!SCANNER_IsScanning())
                 MENU_StartCssScan();
@@ -1893,9 +1896,11 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 
         gRequestDisplayScreen = DISPLAY_MENU;
 
-        if (UI_MENU_GetCurrentMenuId() != MENU_ABR
-            && UI_MENU_GetCurrentMenuId() != MENU_ABR_MIN
-            && UI_MENU_GetCurrentMenuId() != MENU_ABR_MAX
+        const int m = UI_MENU_GetCurrentMenuId();
+
+        if (m != MENU_ABR 
+            && m != MENU_ABR_MIN 
+            && m != MENU_ABR_MAX 
             && gEeprom.BACKLIGHT_TIME == 0) // backlight always off and not in the backlight menu
         {
             BACKLIGHT_TurnOff();
@@ -1960,27 +1965,27 @@ void MENU_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 {
     switch (Key)
     {
-        case KEY_0:
-        case KEY_1:
-        case KEY_2:
-        case KEY_3:
-        case KEY_4:
-        case KEY_5:
-        case KEY_6:
-        case KEY_7:
-        case KEY_8:
-        case KEY_9:
+        case KEY_0...KEY_9:
             MENU_Key_0_to_9(Key, bKeyPressed, bKeyHeld);
             break;
         case KEY_MENU:
             MENU_Key_MENU(bKeyPressed, bKeyHeld);
             break;
-        case KEY_UP:
-            MENU_Key_UP_DOWN(bKeyPressed, bKeyHeld,  1);
-            break;
-        case KEY_DOWN:
-            MENU_Key_UP_DOWN(bKeyPressed, bKeyHeld, -1);
-            break;
+            
+        #if defined(ENABLE_FMRADIO) && defined(ENABLE_SPECTRUM) // The size of the Basic version is increasing, while the others are decreasing, so that's why...
+            case KEY_UP:
+                MENU_Key_UP_DOWN(bKeyPressed, bKeyHeld,  1);
+                break;
+            case KEY_DOWN:
+                MENU_Key_UP_DOWN(bKeyPressed, bKeyHeld, -1);
+                break;
+        #else
+            case KEY_UP:
+            case KEY_DOWN:
+                MENU_Key_UP_DOWN(bKeyPressed, bKeyHeld,  Key == KEY_UP ? 1 : -1);
+                break;
+        #endif
+
         case KEY_EXIT:
             MENU_Key_EXIT(bKeyPressed, bKeyHeld);
             break;
@@ -2018,13 +2023,15 @@ void MENU_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
             break;
     }
 
+    const int m = UI_MENU_GetCurrentMenuId();
+
     if (gScreenToDisplay == DISPLAY_MENU)
     {
-        if (UI_MENU_GetCurrentMenuId() == MENU_VOL ||
+        if (m == MENU_VOL ||
             #ifdef ENABLE_F_CAL_MENU
-                UI_MENU_GetCurrentMenuId() == MENU_F_CALI ||
+                m == MENU_F_CALI ||
             #endif
-            UI_MENU_GetCurrentMenuId() == MENU_BATCAL)
+            m == MENU_BATCAL)
         {
             gMenuCountdown = menu_timeout_long_500ms;
         }

--- a/app/scanner.c
+++ b/app/scanner.c
@@ -275,10 +275,8 @@ void SCANNER_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
             SCANNER_Key_MENU(bKeyPressed, bKeyHeld);
             break;
         case KEY_UP:
-            SCANNER_Key_UP_DOWN(bKeyPressed, bKeyHeld,  1);
-            break;
         case KEY_DOWN:
-            SCANNER_Key_UP_DOWN(bKeyPressed, bKeyHeld, -1);
+            SCANNER_Key_UP_DOWN(bKeyPressed, bKeyHeld, Key == KEY_UP ? 1 : -1);
             break;
         case KEY_EXIT:
             SCANNER_Key_EXIT(bKeyPressed, bKeyHeld);

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -50,7 +50,7 @@ const uint16_t RSSI_MAX_VALUE = 65535;
 static uint32_t initialFreq;
 static char String[32];
 
-bool isInitialized = false;
+static bool isInitialized = false;
 bool isListening = true;
 bool monitorMode = false;
 bool redrawStatus = true;
@@ -64,7 +64,7 @@ State currentState = SPECTRUM, previousState = SPECTRUM;
 
 PeakInfo peak;
 ScanInfo scanInfo;
-KeyboardState kbd = {KEY_INVALID, KEY_INVALID, 0};
+static KeyboardState kbd = {KEY_INVALID, KEY_INVALID, 0};
 
 #ifdef ENABLE_SCAN_RANGES
 static uint16_t blacklistFreqs[15];
@@ -785,11 +785,13 @@ static void ToggleBacklight()
     settings.backlightState = !settings.backlightState;
     if (settings.backlightState)
     {
-        BACKLIGHT_TurnOn();
+        // BACKLIGHT_TurnOn();
+        BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MAX);
     }
     else
     {
-        BACKLIGHT_TurnOff();
+        // BACKLIGHT_TurnOff();
+        BACKLIGHT_SetBrightness(gEeprom.BACKLIGHT_MIN);
     }
 }
 
@@ -952,16 +954,16 @@ uint8_t Rssi2Y(uint16_t rssi)
                 // Total width units = (bars - 1) full bars + 2 half bars = bars
                 // First bar: half width, middle bars: full width, last bar: half width
                 // Scale: 128 pixels / (bars - 1) = pixels per full bar
-                uint16_t fullWidth = 128 * 2 / (bars - 1);  // x2 for precision
+                uint16_t fullWidth = (128 << 8) / (bars - 1);  // x256 for precision
                 
                 if (i == 0)
                 {
-                    x = fullWidth / 4;  // half of half (because fullWidth is x2)
+                    x = fullWidth / (2 << 8);  // half of /256 (because fullWidth is x256)
                 }
                 else
                 {
                     // Position = half + (i-1) full bars + current bar
-                    x = fullWidth / 4 + (uint16_t)i * fullWidth / 2;
+                    x = fullWidth / (2 << 8) + (uint16_t)i * fullWidth / (1 << 8);
                     if (i == bars - 1) x = 128;  // Last bar ends at screen edge
                 }
             }
@@ -1526,7 +1528,7 @@ static void Render()
     ST7565_BlitFullScreen();
 }
 
-bool HandleUserInput()
+static bool HandleUserInput()
 {
     kbd.prev = kbd.current;
     kbd.current = GetKey();
@@ -1588,7 +1590,7 @@ static void UpdateScan()
 {
     Scan();
 
-    if (scanInfo.i < scanInfo.measurementsCount)
+    if (scanInfo.i + 1 < scanInfo.measurementsCount)
     {
         NextScanStep();
         return;
@@ -1748,7 +1750,7 @@ static void Tick()
         Render();
         // For screenshot
         #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-            getScreenShot(false);
+            SCREENSHOT_Update(false);
         #endif
         redrawScreen = false;
     }
@@ -1756,6 +1758,8 @@ static void Tick()
 
 void APP_RunSpectrum()
 {
+    settings.backlightState = gEeprom.BACKLIGHT_TIME == 0 ? false : true;
+
     // TX here coz it always? set to active VFO
     vfo = gEeprom.TX_VFO;
 #ifdef ENABLE_FEAT_F4HWN_SPECTRUM
@@ -1818,4 +1822,6 @@ void APP_RunSpectrum()
     {
         Tick();
     }
+
+    BACKLIGHT_TurnOn();
 }

--- a/audio.c
+++ b/audio.c
@@ -51,12 +51,7 @@ void AUDIO_PlayBeep(BEEP_Type_t Beep)
 #endif
        !gEeprom.BEEP_CONTROL)
         return;
-
-#ifdef ENABLE_AIRCOPY
-    if (gScreenToDisplay == DISPLAY_AIRCOPY)
-        return;
-#endif
-
+        
     if (gCurrentFunction == FUNCTION_RECEIVE)
         return;
 

--- a/audio.c
+++ b/audio.c
@@ -34,6 +34,13 @@
 
 BEEP_Type_t gBeepToPlay = BEEP_NONE;
 
+static void AUDIO_PlayBeepPulse(void) {
+    BK4819_ExitTxMute();
+    SYSTEM_DelayMs(60);
+    BK4819_EnterTxMute();
+    SYSTEM_DelayMs(20);
+}
+
 void AUDIO_PlayBeep(BEEP_Type_t Beep)
 {
 
@@ -126,17 +133,11 @@ void AUDIO_PlayBeep(BEEP_Type_t Beep)
     switch (Beep)
     {
         case BEEP_880HZ_60MS_DOUBLE_BEEP:
-            BK4819_ExitTxMute();
-            SYSTEM_DelayMs(60);
-            BK4819_EnterTxMute();
-            SYSTEM_DelayMs(20);
+            AUDIO_PlayBeepPulse();
             [[fallthrough]];
         case BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL:
         case BEEP_500HZ_60MS_DOUBLE_BEEP:
-            BK4819_ExitTxMute();
-            SYSTEM_DelayMs(60);
-            BK4819_EnterTxMute();
-            SYSTEM_DelayMs(20);
+            AUDIO_PlayBeepPulse();
             [[fallthrough]];
         case BEEP_1KHZ_60MS_OPTIONAL:
             BK4819_ExitTxMute();
@@ -175,11 +176,18 @@ void AUDIO_PlayBeep(BEEP_Type_t Beep)
     SYSTEM_DelayMs(5);
     BK4819_WriteRegister(BK4819_REG_71, ToneConfig);
 
+#ifdef ENABLE_FMRADIO
+    const bool isFmRadio = gFmRadioMode;
+
+    if (isFmRadio)
+        SYSTEM_DelayMs(10);
+#endif
+
     if (gEnableSpeaker)
         AUDIO_AudioPathOn();
 
 #ifdef ENABLE_FMRADIO
-    if (gFmRadioMode)
+    if (isFmRadio)
         BK1080_Mute(false);
 #endif
 

--- a/dcs.c
+++ b/dcs.c
@@ -15,10 +15,7 @@
  */
 
 #include "dcs.h"
-
-#ifndef ARRAY_SIZE
-    #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-#endif
+#include "misc.h"
 
 // CTCSS Hz * 10
 const uint16_t CTCSS_Options[50] = {

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 
 #include "settings.h"
+#include "misc.h"
 
 #include "../audio.h"
 #include "../bsp/dp32g030/gpio.h"
@@ -27,11 +28,6 @@
 #include "gpio.h"
 #include "system.h"
 #include "systick.h"
-
-
-#ifndef ARRAY_SIZE
-    #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-#endif
 
 static const uint16_t FSK_RogerTable[7] = {0xF1A2, 0x7446, 0x61A4, 0x6544, 0x4E8A, 0xE044, 0xEA84};
 

--- a/driver/keyboard.c
+++ b/driver/keyboard.c
@@ -151,3 +151,8 @@ KEY_Code_t KEYBOARD_Poll(void)
 
     return Key;
 }
+
+void HideFKeyIcon(void) {
+    gWasFKeyPressed       = false;
+    gUpdateStatus         = true;
+}

--- a/driver/keyboard.h
+++ b/driver/keyboard.h
@@ -52,5 +52,7 @@ extern bool       gWasFKeyPressed;
 
 KEY_Code_t KEYBOARD_Poll(void);
 
+void HideFKeyIcon(void);
+
 #endif
 

--- a/frequencies.c
+++ b/frequencies.c
@@ -163,11 +163,8 @@ int32_t TX_freq_check(const uint32_t Frequency)
 {   // return '0' if TX frequency is allowed
     // otherwise return '-1'
 
-    if (Frequency < frequencyBandTable[0].lower || Frequency > frequencyBandTable[BAND_N_ELEM - 1].upper)
-        return -1;  // not allowed outside this range
-
-    if (Frequency >= BX4819_band1.upper && Frequency < BX4819_band2.lower)
-        return -1;  // BX chip does not work in this range
+    if (RX_freq_check(Frequency))
+        return -1;
 
     switch (gSetting_F_LOCK)
     {
@@ -280,10 +277,10 @@ int32_t RX_freq_check(const uint32_t Frequency)
     // otherwise return '-1'
 
     if (Frequency < frequencyBandTable[0].lower || Frequency > frequencyBandTable[BAND_N_ELEM - 1].upper)
-        return -1;
+        return -1;  // not allowed outside this range
 
     if (Frequency >= BX4819_band1.upper && Frequency < BX4819_band2.lower)
-        return -1;
+        return -1;  // BX chip does not work in this range
 
-    return 0;   // OK frequency
+    return 0;  // OK frequency
 }

--- a/functions.c
+++ b/functions.c
@@ -119,14 +119,7 @@ void FUNCTION_Foreground(const FUNCTION_Type_t PreviousFunction)
 
 void FUNCTION_PowerSave() {
     #ifdef ENABLE_FEAT_F4HWN_SLEEP
-        if(gWakeUp)
-        {
-            gPowerSave_10ms = gEeprom.BATTERY_SAVE * 200; // deep sleep now indexed on BatSav
-        }
-        else
-        {
-            gPowerSave_10ms = gEeprom.BATTERY_SAVE * 10;
-        }
+        gPowerSave_10ms = gEeprom.BATTERY_SAVE * (gWakeUp ? 200 : 10); // deep sleep now indexed on BatSav
     #else
         gPowerSave_10ms = gEeprom.BATTERY_SAVE * 10;
     #endif

--- a/helper/boot.c
+++ b/helper/boot.c
@@ -62,8 +62,10 @@ BOOT_Mode_t BOOT_GetMode(void)
             return BOOT_MODE_F_LOCK;
 
         #ifdef ENABLE_AIRCOPY
-            if (Keys[0] == KEY_SIDE2)
+            if (Keys[0] == KEY_SIDE2) {
+                gAirCopyBootMode = true;
                 return BOOT_MODE_AIRCOPY;
+            }
         #endif
     }
 

--- a/main.c
+++ b/main.c
@@ -291,77 +291,38 @@ void Main(void)
 #endif
     }
 
-    /*
     #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
-    if(gEeprom.CURRENT_STATE == 2 || gEeprom.CURRENT_STATE == 5)
-    {
-            gScanRangeStart = gScanRangeStart ? 0 : gTxVfo->pRX->Frequency;
-            gScanRangeStop = gEeprom.VfoInfo[!gEeprom.TX_VFO].freq_config_RX.Frequency;
-            if(gScanRangeStart > gScanRangeStop)
-            {
-                SWAP(gScanRangeStart, gScanRangeStop);
-            }
-    }
-    switch (gEeprom.CURRENT_STATE) {
-        case 1:
-            gEeprom.SCAN_LIST_DEFAULT = gEeprom.CURRENT_LIST;
-            CHFRSCANNER_Start(true, SCAN_FWD);
-            break;
+        if (gEeprom.CURRENT_STATE == 2 || gEeprom.CURRENT_STATE == 5)
+            CHFRSCANNER_ScanRange();
 
-        case 2:
-            CHFRSCANNER_Start(true, SCAN_FWD);
-            break;
+        switch (gEeprom.CURRENT_STATE) {
+            case 1:
+                gEeprom.SCAN_LIST_DEFAULT = gEeprom.CURRENT_LIST;
+                CHFRSCANNER_Start(true, SCAN_FWD);
+                break;
 
-        #ifdef ENABLE_FMRADIO
-        case 3:
-            ACTION_FM();
-            GUI_SelectNextDisplay(gRequestDisplayScreen);
-            break;
-        #endif
+            case 2:
+                CHFRSCANNER_Start(true, SCAN_FWD);
+                break;
 
-        #ifdef ENABLE_SPECTRUM
-        case 4:
-            APP_RunSpectrum();
-            break;
-        case 5:
-            APP_RunSpectrum();
-            break;
-        #endif
+            #ifdef ENABLE_FMRADIO
+                case 3:
+                    ACTION_FM();
+                    GUI_SelectNextDisplay(gRequestDisplayScreen);
+                    break;
+            #endif
 
-        default:
-            // No action for CURRENT_STATE == 0 or other unexpected values
-            break;
-    }
-    #endif
-    */
+            #ifdef ENABLE_SPECTRUM
+                case 4:
+                case 5:
+                    APP_RunSpectrum();
+                    break;
+            #endif
 
-    #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
-        if (gEeprom.CURRENT_STATE == 2 || gEeprom.CURRENT_STATE == 5) {
-            gScanRangeStart = gScanRangeStart ? 0 : gTxVfo->pRX->Frequency;
-            gScanRangeStop = gEeprom.VfoInfo[!gEeprom.TX_VFO].freq_config_RX.Frequency;
-            if (gScanRangeStart > gScanRangeStop) {
-                SWAP(gScanRangeStart, gScanRangeStop);
-            }
+            default:
+                // No action for CURRENT_STATE == 0 or other unexpected values
+                break;
         }
-
-        if (gEeprom.CURRENT_STATE == 1) {
-            gEeprom.SCAN_LIST_DEFAULT = gEeprom.CURRENT_LIST;
-        }
-
-        if (gEeprom.CURRENT_STATE == 1 || gEeprom.CURRENT_STATE == 2) {
-            CHFRSCANNER_Start(true, SCAN_FWD);
-        }
-        #ifdef ENABLE_FMRADIO
-        else if (gEeprom.CURRENT_STATE == 3) {
-            ACTION_FM();
-            GUI_SelectNextDisplay(gRequestDisplayScreen);
-        }
-        #endif
-        #ifdef ENABLE_SPECTRUM
-        else if (gEeprom.CURRENT_STATE == 4 || gEeprom.CURRENT_STATE == 5) {
-            APP_RunSpectrum();
-        }
-        #endif
     #endif
         
     while (true) {

--- a/misc.c
+++ b/misc.c
@@ -232,6 +232,7 @@ volatile uint16_t gScanPauseDelayIn_10ms;
 uint16_t          gMenuCountdown;
 bool              gPttWasReleased;
 bool              gPttWasPressed;
+bool              gHasVfoBackup;
 uint8_t           gKeypadLocked;
 bool              gFlagReconfigureVfos;
 uint8_t           gVfoConfigureMode;

--- a/misc.c
+++ b/misc.c
@@ -136,9 +136,12 @@ enum BacklightOnRxTx_t gSetting_backlight_on_tx_rx;
     uint8_t       gDW = 0;
     uint8_t       gCB = 0;
     bool          gSaveRxMode = false;
-    uint8_t       crc[15] = { 0 };
-    uint8_t       lErrorsDuringAirCopy = 0;
-    uint8_t       gAircopyStep = 0;
+    #ifdef ENABLE_AIRCOPY
+        uint8_t       crc[15] = { 0 };
+        uint8_t       lErrorsDuringAirCopy = 0;
+        uint8_t       gAircopyStep = 0;
+        bool          gAirCopyBootMode = 0;
+    #endif
     #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
         bool          gPowerHigh = false;
         bool          gRemoveOffset = false;

--- a/misc.h
+++ b/misc.h
@@ -304,6 +304,7 @@ extern AlarmState_t          gAlarmState;
 extern uint16_t              gMenuCountdown;
 extern bool                  gPttWasReleased;
 extern bool                  gPttWasPressed;
+extern bool                  gHasVfoBackup;
 extern bool                  gFlagReconfigureVfos;
 extern uint8_t               gVfoConfigureMode;
 extern bool                  gFlagResetVfos;

--- a/misc.h
+++ b/misc.h
@@ -189,9 +189,12 @@ extern enum BacklightOnRxTx_t gSetting_backlight_on_tx_rx;
     extern uint8_t            gDW;
     extern uint8_t            gCB;
     extern bool               gSaveRxMode;
-    extern uint8_t            crc[15];
-    extern uint8_t            lErrorsDuringAirCopy;
-    extern uint8_t            gAircopyStep;
+    #ifdef ENABLE_AIRCOPY
+        extern uint8_t            crc[15];
+        extern uint8_t            lErrorsDuringAirCopy;
+        extern uint8_t            gAircopyStep;
+        extern bool               gAirCopyBootMode;
+    #endif
     #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
         extern bool               gPowerHigh;
         extern bool               gRemoveOffset;

--- a/radio.c
+++ b/radio.c
@@ -157,6 +157,28 @@ void RADIO_InitInfo(VFO_Info_t *pInfo, const uint8_t ChannelSave, const uint32_t
     RADIO_ConfigureSquelchAndOutputPower(pInfo);
 }
 
+void RADIO_ValidateAndSetCode(FREQ_Config_t *pFreq_Config, uint8_t tmp) {
+    switch (pFreq_Config->CodeType) {
+        default:
+        case CODE_TYPE_OFF:
+            pFreq_Config->CodeType = CODE_TYPE_OFF;
+            tmp = 0;
+            break;
+
+        case CODE_TYPE_CONTINUOUS_TONE:
+            if (tmp > (ARRAY_SIZE(CTCSS_Options) - 1))
+                tmp = 0;
+            break;
+
+        case CODE_TYPE_DIGITAL:
+        case CODE_TYPE_REVERSE_DIGITAL:
+            if (tmp > (ARRAY_SIZE(DCS_Options) - 1))
+                tmp = 0;
+            break;
+    }
+    pFreq_Config->Code = tmp;
+}
+
 void RADIO_ConfigureChannel(const unsigned int VFO, const unsigned int configure)
 {
     VFO_Info_t *pVfo = &gEeprom.VfoInfo[VFO];
@@ -283,49 +305,8 @@ void RADIO_ConfigureChannel(const unsigned int VFO, const unsigned int configure
         pVfo->freq_config_RX.CodeType = (data[2] >> 0) & 0x0F;
         pVfo->freq_config_TX.CodeType = (data[2] >> 4) & 0x0F;
 
-        tmp = data[0];
-        switch (pVfo->freq_config_RX.CodeType)
-        {
-            default:
-            case CODE_TYPE_OFF:
-                pVfo->freq_config_RX.CodeType = CODE_TYPE_OFF;
-                tmp = 0;
-                break;
-
-            case CODE_TYPE_CONTINUOUS_TONE:
-                if (tmp > (ARRAY_SIZE(CTCSS_Options) - 1))
-                    tmp = 0;
-                break;
-
-            case CODE_TYPE_DIGITAL:
-            case CODE_TYPE_REVERSE_DIGITAL:
-                if (tmp > (ARRAY_SIZE(DCS_Options) - 1))
-                    tmp = 0;
-                break;
-        }
-        pVfo->freq_config_RX.Code = tmp;
-
-        tmp = data[1];
-        switch (pVfo->freq_config_TX.CodeType)
-        {
-            default:
-            case CODE_TYPE_OFF:
-                pVfo->freq_config_TX.CodeType = CODE_TYPE_OFF;
-                tmp = 0;
-                break;
-
-            case CODE_TYPE_CONTINUOUS_TONE:
-                if (tmp > (ARRAY_SIZE(CTCSS_Options) - 1))
-                    tmp = 0;
-                break;
-
-            case CODE_TYPE_DIGITAL:
-            case CODE_TYPE_REVERSE_DIGITAL:
-                if (tmp > (ARRAY_SIZE(DCS_Options) - 1))
-                    tmp = 0;
-                break;
-        }
-        pVfo->freq_config_TX.Code = tmp;
+        RADIO_ValidateAndSetCode(&pVfo->freq_config_RX, data[0]);
+        RADIO_ValidateAndSetCode(&pVfo->freq_config_TX, data[1]);
 
         if (data[4] == 0xFF)
         {
@@ -1202,17 +1183,19 @@ void RADIO_PrepareTX(void)
 
 void RADIO_SendCssTail(void)
 {
-    switch (gCurrentVfo->pTX->CodeType) {
-    case CODE_TYPE_DIGITAL:
-    case CODE_TYPE_REVERSE_DIGITAL:
-        BK4819_PlayCDCSSTail();
-        break;
-    default:
-        BK4819_PlayCTCSSTail();
-        break;
-    }
+    if (gEeprom.TAIL_TONE_ELIMINATION) {
+        switch (gCurrentVfo->pTX->CodeType) {
+        case CODE_TYPE_DIGITAL:
+        case CODE_TYPE_REVERSE_DIGITAL:
+            BK4819_PlayCDCSSTail();
+            break;
+        default:
+            BK4819_PlayCTCSSTail();
+            break;
+        }
 
-    SYSTEM_DelayMs(200);
+        SYSTEM_DelayMs(200);
+    }
 }
 
 void RADIO_SendEndOfTransmission(void)
@@ -1221,8 +1204,7 @@ void RADIO_SendEndOfTransmission(void)
     DTMF_SendEndOfTransmission();
 
     // send the CTCSS/DCS tail tone - allows the receivers to mute the usual FM squelch tail/crash
-    if(gEeprom.TAIL_TONE_ELIMINATION)
-        RADIO_SendCssTail();
+    RADIO_SendCssTail();
     RADIO_SetupRegisters(false);
 }
 
@@ -1232,7 +1214,6 @@ void RADIO_PrepareCssTX(void)
 
     SYSTEM_DelayMs(200);
 
-    if(gEeprom.TAIL_TONE_ELIMINATION)
-        RADIO_SendCssTail();
+    RADIO_SendCssTail();
     RADIO_SetupRegisters(true);
 }

--- a/screenshot.c
+++ b/screenshot.c
@@ -19,11 +19,23 @@
 #include "screenshot.h"
 #include "misc.h"
 
-void getScreenShot(bool force)
+void SCREENSHOT_Line(uint8_t *src, uint8_t *dest, uint16_t *idx) {
+    for (uint8_t b = 0; b < 8; b++) {
+        for (uint8_t i = 0; i < 128; i += 8) {
+            uint8_t acc = 0;
+            for (uint8_t k = 0; k < 8; k++) {
+                if (src[i + k] & (1 << b)) acc |= (1 << k);
+            }
+            dest[(*idx)++] = gSetting_set_inv ? ~acc : acc;
+        }
+    }
+}
+
+void SCREENSHOT_Update(bool force)
 {
     static uint8_t previousFrame[1024] = {0}; // Last transmitted frame
     static uint8_t forcedBlock = 0;           // Block forced for refresh on each frame
-    static uint8_t keepAlive = 10;            // Keepalive counter
+    static uint8_t keepAlive = 3;             // Keepalive counter
 
     // Use a single buffer to reduce stack usage
     static uint8_t currentFrame[1024];        // Current frame
@@ -39,7 +51,7 @@ void getScreenShot(bool force)
     }
 
     if (UART_IsCableConnected()) {
-        keepAlive = 10;
+        keepAlive = 15;
     }
 
     if (keepAlive > 0) {
@@ -51,31 +63,11 @@ void getScreenShot(bool force)
     }
 
     // Build current frame from status line (first 8 lines)
-    for (uint8_t b = 0; b < 8; b++) {
-        for (uint8_t i = 0; i < 128; i++) {
-            uint8_t bit = (gStatusLine[i] >> b) & 0x01;
-            acc |= (bit << bitCount++);
-            if (bitCount == 8) {
-                currentFrame[index++] = acc;
-                acc = 0;
-                bitCount = 0;
-            }
-        }
-    }
+    SCREENSHOT_Line(gStatusLine, currentFrame, &index);
 
     // Build remaining part of the frame (7 * 8 lines)
     for (uint8_t l = 0; l < 7; l++) {
-        for (uint8_t b = 0; b < 8; b++) {
-            for (uint8_t i = 0; i < 128; i++) {
-                uint8_t bit = (gFrameBuffer[l][i] >> b) & 0x01;
-                acc |= (bit << bitCount++);
-                if (bitCount == 8) {
-                    currentFrame[index++] = acc;
-                    acc = 0;
-                    bitCount = 0;
-                }
-            }
-        }
+        SCREENSHOT_Line(gFrameBuffer[l], currentFrame, &index);
     }
 
     if (bitCount > 0)

--- a/screenshot.h
+++ b/screenshot.h
@@ -17,6 +17,6 @@
 #ifndef SCREENSHOT_H
 #define SCREENSHOT_H
 
-void getScreenShot(bool force);
+void SCREENSHOT_Update(bool force);
 
 #endif

--- a/ui/fmradio.c
+++ b/ui/fmradio.c
@@ -35,6 +35,10 @@ void UI_DisplayFM(void)
     char *pPrintStr = String;
     UI_DisplayClear();
 
+#ifdef ENABLE_FEAT_F4HWN
+    UI_DisplayUnlockKeyboard(5);
+#endif
+
     UI_PrintString("FM", 2, 0, 0, 8);
 
     sprintf(String, "%d%s-%dM", 

--- a/ui/helper.c
+++ b/ui/helper.c
@@ -22,6 +22,7 @@
 #include "ui/helper.h"
 #include "ui/inputbox.h"
 #include "misc.h"
+#include "settings.h"
 
 #ifndef ARRAY_SIZE
     #define ARRAY_SIZE(arr) (sizeof(arr)/sizeof((arr)[0]))
@@ -292,6 +293,23 @@ static void sort(int16_t *a, int16_t *b)
         }
         x += 4;
       }
+    }
+
+    void UI_DisplayUnlockKeyboard(uint8_t shift) {
+        if (gEeprom.KEY_LOCK && gKeypadLocked > 0)
+        {   // tell user how to unlock the keyboard
+            
+            //memcpy(gFrameBuffer[shift] + 2, gFontKeyLock, sizeof(gFontKeyLock));
+            UI_PrintStringSmallBold("UNLOCK KEYBOARD", 12, 0, shift);
+            //memcpy(gFrameBuffer[shift] + 120, gFontKeyLock, sizeof(gFontKeyLock));
+
+            /*
+            for (uint8_t i = 12; i < 116; i++)
+            {
+                gFrameBuffer[shift][i] ^= 0xFF;
+            }
+            */
+        }
     }
 #endif
     

--- a/ui/helper.h
+++ b/ui/helper.h
@@ -37,6 +37,7 @@ void UI_DrawPixelBuffer(uint8_t (*buffer)[128], uint8_t x, uint8_t y, bool black
     void PutPixel(uint8_t x, uint8_t y, bool fill);
     void PutPixelStatus(uint8_t x, uint8_t y, bool fill);
     void GUI_DisplaySmallest(const char *pString, uint8_t x, uint8_t y, bool statusbar, bool fill);
+    void UI_DisplayUnlockKeyboard(uint8_t shift);
 #endif
 void UI_DrawLineBuffer(uint8_t (*buffer)[128], int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool black);
 void UI_DrawRectangleBuffer(uint8_t (*buffer)[128], int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool black);

--- a/ui/main.c
+++ b/ui/main.c
@@ -1130,11 +1130,8 @@ void UI_DisplayMain(void)
             break;
 
             case 2:
-            sprintf(String, "%03oN", DCS_Options[pConfig->Code]);
-            break;
-
             case 3:
-            sprintf(String, "%03oI", DCS_Options[pConfig->Code]);
+            sprintf(String, (int)pConfig->CodeType == 2 ? "%03oN" : "%03oI", DCS_Options[pConfig->Code]);
             break;
 
             default:

--- a/ui/main.c
+++ b/ui/main.c
@@ -79,7 +79,7 @@ const char *VfoStateStr[] = {
        [VFO_STATE_VOLTAGE_HIGH]="VOLT HIGH"
 };
 
-// ***************************************************************************
+// ----------------------------------------
 
 static void DrawSmallAntennaAndBars(uint8_t *p, unsigned int level)
 {
@@ -326,22 +326,34 @@ void DisplayRSSIBar(const bool now)
 #endif
         + dBmCorrTable[gRxVfo->Band];
 
-    rssi_dBm = -rssi_dBm;
-
-    if(rssi_dBm > 141) rssi_dBm = 141;
-    if(rssi_dBm < 53) rssi_dBm = 53;
-
-    uint8_t s_level = 0;
-    uint8_t overS9dBm = 0;
+    // IARU VHF/UHF S-meter: S9 = -93 dBm, 1 S-unit = 6 dB
+    // S(n) threshold = -93 + (n - 9) * 6
+    uint8_t s_level    = 0;
+    uint8_t overS9dBm  = 0;
     uint8_t overS9Bars = 0;
 
-    if(rssi_dBm >= 93) {
-        s_level = map(rssi_dBm, 141, 93, 1, 9);
-    }
-    else {
+    // if      (rssi_dBm >= -93)  s_level = 9;  // S9  = -93 dBm
+    // else if (rssi_dBm >= -99)  s_level = 8;  // S8  = -99 dBm
+    // else if (rssi_dBm >= -105) s_level = 7;  // S7  = -105 dBm
+    // else if (rssi_dBm >= -111) s_level = 6;  // S6  = -111 dBm
+    // else if (rssi_dBm >= -117) s_level = 5;  // S5  = -117 dBm
+    // else if (rssi_dBm >= -123) s_level = 4;  // S4  = -123 dBm
+    // else if (rssi_dBm >= -129) s_level = 3;  // S3  = -129 dBm
+    // else if (rssi_dBm >= -135) s_level = 2;  // S2  = -135 dBm
+    // else if (rssi_dBm >= -141) s_level = 1;  // S1  = -141 dBm
+    // else                       s_level = 0;  // S0 (below -141 dBm)
+
+    if (rssi_dBm >= -93)
         s_level = 9;
-        overS9dBm = map(rssi_dBm, 93, 53, 0, 40);
-        overS9Bars = map(overS9dBm, 0, 40, 0, 4);
+    else if (rssi_dBm < -141)
+        s_level = 0;
+    else 
+        s_level = (rssi_dBm + 147) / 6;
+
+    if (s_level == 9) {
+        // Compute over-S9 dB directly
+        overS9dBm  = (uint8_t)MIN(rssi_dBm - (-93), 40);
+        overS9Bars = overS9dBm / 10;
     }
 #else
     const int16_t s0_dBm   = -gEeprom.S0_LEVEL;                  // S0 .. base level
@@ -361,12 +373,12 @@ void DisplayRSSIBar(const bool now)
 #ifdef ENABLE_FEAT_F4HWN
     if (gSetting_set_gui)
     {
-        sprintf(str, "%3d", -rssi_dBm);
+        sprintf(str, "%3d", rssi_dBm);
         UI_PrintStringSmallNormal(str, LCD_WIDTH + 8, 0, line - 1);
     }
     else
     {
-        sprintf(str, "% 4d %s", -rssi_dBm, "dBm");
+        sprintf(str, "% 4d %s", rssi_dBm, "dBm");
         if(isMainOnly())
             GUI_DisplaySmallest(str, 2, 41, false, true);
         else
@@ -523,7 +535,7 @@ void UI_MAIN_TimeSlice500ms(void)
     }
 }
 
-// ***************************************************************************
+// ----------------------------------------
 
 void UI_DisplayMain(void)
 {
@@ -549,32 +561,7 @@ void UI_DisplayMain(void)
         return;
     }
 #else
-    if (gEeprom.KEY_LOCK && gKeypadLocked > 0)
-    {   // tell user how to unlock the keyboard
-        uint8_t shift = 3;
-
-        /*
-        BK4819_ToggleGpioOut(BK4819_GPIO5_PIN1_RED, true);
-        SYSTEM_DelayMs(50);
-        BK4819_ToggleGpioOut(BK4819_GPIO5_PIN1_RED, false);
-        SYSTEM_DelayMs(50);
-        */
-
-        if(isMainOnly())
-        {
-            shift = 5;
-        }
-        //memcpy(gFrameBuffer[shift] + 2, gFontKeyLock, sizeof(gFontKeyLock));
-        UI_PrintStringSmallBold("UNLOCK KEYBOARD", 12, 0, shift);
-        //memcpy(gFrameBuffer[shift] + 120, gFontKeyLock, sizeof(gFontKeyLock));
-
-        /*
-        for (uint8_t i = 12; i < 116; i++)
-        {
-            gFrameBuffer[shift][i] ^= 0xFF;
-        }
-        */
-    }
+    UI_DisplayUnlockKeyboard(isMainOnly() ? 5 : 3);
 #endif
 
     unsigned int activeTxVFO = gRxVfoIsActive ? gEeprom.RX_VFO : gEeprom.TX_VFO;
@@ -736,7 +723,7 @@ void UI_DisplayMain(void)
 
         uint32_t frequency = gEeprom.VfoInfo[vfo_num].pRX->Frequency;
 
-        if(TX_freq_check(frequency) != 0 && gEeprom.VfoInfo[vfo_num].TX_LOCK == true)
+        if(TX_freq_check(frequency) != 0 && gEeprom.VfoInfo[vfo_num].TX_LOCK == true && !FUNCTION_IsRx())
         {
             if(isMainOnly())
                 memcpy(p_line0 + 14, BITMAP_VFO_Lock, sizeof(BITMAP_VFO_Lock));
@@ -764,29 +751,27 @@ void UI_DisplayMain(void)
         {   // receiving .. show the RX symbol
             mode = VFO_MODE_RX;
             //if (FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num) {
-            if (FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num && VfoState[vfo_num] == VFO_STATE_NORMAL) {
+            if (FUNCTION_IsRx()) {
+                if (gEeprom.RX_VFO == vfo_num && VfoState[vfo_num] == VFO_STATE_NORMAL) {
 #ifdef ENABLE_FEAT_F4HWN
-                RxBlinkLed = 1;
-                RxBlinkLedCounter = 0;
-                RxLine = line;
-                RxOnVfofrequency = frequency;
-                if(!isMainVFO)
-                {
-                    RxBlink = 1;
-                }
-                else
-                {
-                    RxBlink = 0;
-                }
+                    RxBlinkLed = 1;
+                    RxBlinkLedCounter = 0;
+                    RxLine = line;
+                    RxOnVfofrequency = frequency;
+
+                    RxBlink = !isMainVFO;
 #else
-                UI_PrintStringSmallBold("RX", 8, 0, line);
+                    UI_PrintStringSmallBold("RX", 8, 0, line);
 #endif
-            }
+                }
 #ifdef ENABLE_FEAT_F4HWN
-            else
-            {
-                if(RxOnVfofrequency == frequency && !isMainOnly())
-                {
+                else {
+                    if(RxBlinkLed == 1)
+                        RxBlinkLed = 2;
+                }
+            }
+            else {
+                if(RxOnVfofrequency == frequency && !isMainOnly()) {
                     UI_PrintStringSmallNormal(">>", 8, 0, line);
                     //memcpy(p_line0 + 14, BITMAP_VFO_Default, sizeof(BITMAP_VFO_Default));
                 }
@@ -801,7 +786,7 @@ void UI_DisplayMain(void)
         {   // channel mode
             const unsigned int x = 2;
             const bool inputting = gInputBoxIndex != 0 && gEeprom.TX_VFO == vfo_num;
-            if (!inputting)
+            if (!inputting || gScanStateDir != SCAN_OFF)
                 sprintf(String, "M%u", gEeprom.ScreenChannel[vfo_num] + 1);
             else
                 sprintf(String, "M%.3s", INPUTBOX_GetAscii());  // show the input text
@@ -830,7 +815,7 @@ void UI_DisplayMain(void)
         }
 #endif
 
-        // ************
+        // ----------------------------------------
 
         enum VfoState_t state = VfoState[vfo_num];
 
@@ -1053,7 +1038,7 @@ void UI_DisplayMain(void)
             }
         }
 
-        // ************
+        // ----------------------------------------
 
         {   // show the TX/RX level
             int8_t Level = -1;
@@ -1095,7 +1080,7 @@ void UI_DisplayMain(void)
                 DrawSmallAntennaAndBars(p_line1 + LCD_WIDTH, Level);
         }
 
-        // ************
+        // ----------------------------------------
 
         String[0] = '\0';
         const VFO_Info_t *vfoInfo = &gEeprom.VfoInfo[vfo_num];
@@ -1426,7 +1411,7 @@ void UI_DisplayMain(void)
         if (rx || gCurrentFunction == FUNCTION_FOREGROUND || gCurrentFunction == FUNCTION_POWER_SAVE)
         {
             #if 1
-                if (gSetting_live_DTMF_decoder && gDTMF_RX_live[0] != 0)
+                if (gSetting_live_DTMF_decoder && gDTMF_RX_live[0] != 0 && gKeypadLocked == 0)
                 {   // show live DTMF decode
                     const unsigned int len = strlen(gDTMF_RX_live);
                     const unsigned int idx = (len > (17 - 5)) ? len - (17 - 5) : 0;  // limit to last 'n' chars
@@ -1514,5 +1499,3 @@ void UI_DisplayMain(void)
 
     ST7565_BlitFullScreen();
 }
-
-// ***************************************************************************

--- a/ui/main.c
+++ b/ui/main.c
@@ -1065,9 +1065,15 @@ void UI_DisplayMain(void)
                     Level = 2;
                 }
                 */
-                Level = gRxVfo->OUTPUT_POWER - 1;
+
+                uint8_t currentPower = gRxVfo->OUTPUT_POWER;
+
+                if(currentPower == OUTPUT_POWER_USER)
+                    Level = gSetting_set_pwr;
+                else
+                    Level = currentPower - 1;
             }
-            else
+            else 
             if (mode == VFO_MODE_RX)
             {   // RX signal level
                 #ifndef ENABLE_RSSI_BAR

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -31,9 +31,11 @@
 #include "../helper/battery.h"
 #include "../misc.h"
 #include "../settings.h"
+
 #ifdef ENABLE_FEAT_F4HWN
     #include "../version.h"
 #endif
+
 #include "helper.h"
 #include "inputbox.h"
 #include "menu.h"
@@ -679,15 +681,14 @@ void UI_DisplayMenu(void)
             if (!gIsInSubMenu || gInputBoxIndex == 0)
             {
                 sprintf(String, "%3d.%05u", gSubMenuSelection / 100000, abs(gSubMenuSelection) % 100000);
-                UI_PrintString(String, menu_item_x1, menu_item_x2, 1, 8);
             }
             else
             {
                 const char * ascii = INPUTBOX_GetAscii();
                 sprintf(String, "%.3s.%.3s  ",ascii, ascii + 3);
-                UI_PrintString(String, menu_item_x1, menu_item_x2, 1, 8);
             }
 
+            UI_PrintString(String, menu_item_x1, menu_item_x2, 1, 8);
             UI_PrintString("MHz",  menu_item_x1, menu_item_x2, 3, 8);
 
             already_printed = true;

--- a/ui/status.c
+++ b/ui/status.c
@@ -155,28 +155,34 @@ void UI_DisplayStatus()
             else
         #endif
             {
-                #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-                if(gEeprom.MENU_LOCK == true) {
-                    memcpy(line + x + 2, gFontRO, sizeof(gFontRO));
-                }
-                else
-                {
+                #ifdef ENABLE_AIRCOPY
+                if(!gAirCopyBootMode) {
                 #endif
-                    uint8_t dw = (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF) + (gEeprom.CROSS_BAND_RX_TX != CROSS_BAND_OFF) * 2;
-                    if(dw == 1 || dw == 3) { // DWR - dual watch + respond
-                        if(gDualWatchActive)
-                            memcpy(line + x + (dw==1?0:2), gFontDWR, sizeof(gFontDWR) - (dw==1?0:5));
-                        else
-                            memcpy(line + x + 3, gFontHold, sizeof(gFontHold));
-                    }
-                    else if(dw == 2) { // XB - crossband
-                        memcpy(line + x + 2, gFontXB, sizeof(gFontXB));
+                    #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
+                    if(gEeprom.MENU_LOCK == true) {
+                        memcpy(line + x + 2, gFontRO, sizeof(gFontRO));
                     }
                     else
                     {
-                        memcpy(line + x + 2, gFontMO, sizeof(gFontMO));
+                    #endif
+                        uint8_t dw = (gEeprom.DUAL_WATCH != DUAL_WATCH_OFF) + (gEeprom.CROSS_BAND_RX_TX != CROSS_BAND_OFF) * 2;
+                        if(dw == 1 || dw == 3) { // DWR - dual watch + respond
+                            if(gDualWatchActive)
+                                memcpy(line + x + (dw==1?0:2), gFontDWR, sizeof(gFontDWR) - (dw==1?0:5));
+                            else
+                                memcpy(line + x + 3, gFontHold, sizeof(gFontHold));
+                        }
+                        else if(dw == 2) { // XB - crossband
+                            memcpy(line + x + 2, gFontXB, sizeof(gFontXB));
+                        }
+                        else
+                        {
+                            memcpy(line + x + 2, gFontMO, sizeof(gFontMO));
+                        }
+                    #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
                     }
-                #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
+                    #endif
+                #ifdef ENABLE_AIRCOPY
                 }
                 #endif
             }
@@ -195,15 +201,22 @@ void UI_DisplayStatus()
 
 #ifdef ENABLE_FEAT_F4HWN
     // PTT indicator
-    if (gSetting_set_ptt_session) {
-        memcpy(line + x, gFontPttOnePush, sizeof(gFontPttOnePush));
-        x1 = x + sizeof(gFontPttOnePush) + 1;
+    #ifdef ENABLE_AIRCOPY
+    if(!gAirCopyBootMode) {
+    #endif
+        if (gSetting_set_ptt_session) {
+            memcpy(line + x, gFontPttOnePush, sizeof(gFontPttOnePush));
+            x1 = x + sizeof(gFontPttOnePush) + 1;
+        }
+        else
+        {
+            memcpy(line + x, gFontPttClassic, sizeof(gFontPttClassic));
+            x1 = x + sizeof(gFontPttClassic) + 1;       
+        }
+    #ifdef ENABLE_AIRCOPY
     }
-    else
-    {
-        memcpy(line + x, gFontPttClassic, sizeof(gFontPttClassic));
-        x1 = x + sizeof(gFontPttClassic) + 1;       
-    }
+    #endif
+    
     x += sizeof(gFontPttClassic) + 3;
 #endif
 
@@ -218,15 +231,8 @@ void UI_DisplayStatus()
         size = sizeof(gFontKeyLock);
     }
     else if (gWasFKeyPressed) {
-        #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-        if (!gEeprom.MENU_LOCK) {
-            src = gFontF;
-            size = sizeof(gFontF);
-        }
-        #else
         src = gFontF;
         size = sizeof(gFontF);
-        #endif
     }
     #ifdef ENABLE_FEAT_F4HWN
         else if (gMute) {

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -94,9 +94,8 @@ void GUI_SelectNextDisplay(GUI_DisplayType_t Display)
         gAskForConfirmation  = 0;
         gAskToSave           = false;
         gAskToDelete         = false;
-        gWasFKeyPressed      = false;
 
-        gUpdateStatus        = true;
+        HideFKeyIcon();
     }
 
     gScreenToDisplay = Display;

--- a/ui/welcome.c
+++ b/ui/welcome.c
@@ -204,7 +204,7 @@ void UI_DisplayWelcome(void)
         ST7565_BlitFullScreen();
 
         #ifdef ENABLE_FEAT_F4HWN_SCREENSHOT
-            getScreenShot(true);
+            SCREENSHOT_Update(true);
         #endif
     }
 }


### PR DESCRIPTION
**Hello.**

After many hours of struggling to figure out why the Basic version exceeds the size limit, I would like to present this pull request, which includes the vast majority of the bug fixes and changes made in version V3.

Before I start listing the changes made to the code, I want to mention that I DON'T HAVE THE V1 VERSION OF THE RADIO... I have no way to test the changes, so I'll have to leave that up to you. I doubt anything won't work, but it's always worth checking.

# Changelog

- Major code optimization (536 bytes saved): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/28500e1667c061801d935b8c86873c67d98e7293
- Major code refactoring: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/e28177cb9b5ab50c43c4fd66dc56bd994aaeed40
- Enable beeps for Aircopy, minor code refactoring: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/7c343a2b3e51210832604e069a1e68b23a5d189b
- Code refactoring; improvements to K5Viewer and the UI: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/9574376d3816fbc3f257a61b4c113f567f46c59b
```As for K5Viewer, I only migrated SetInv.```

- Reduce the lag between consecutive RX on both frequencies under DW mode (issue # 198): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/d826cbd138b3887ff749de740dfebe3a1200ec27
- Fix SCAN_SAVE_CHANNEL and UI_GenerateChannelStringEx: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/85f1bfdb7f2bf384c7ef321f21b88f3b091114aa
```No changes to the 4-digit channel number```

- Fix Bandscope + Game: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/c901b2edc576c043c53f861832ef5a1a20616e03
- Fix breakout: reliable key handling from K5Viewer (issue armel#214): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/f5d6f5782bba20bc14ec57540fc7b4b0fd7adf41
```No changes regarding the key handling from K5Viewer```

- FM_CheckFrequencyLock() refactoring: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/d9eb55fccf35746840e82e01f561667e1ab44142
- Fix issue # 40: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/0ddbb0ad82c618147e30f978c35c046d1c33f48a
- Fix MR channel persistence when entered with leading zeros (Thanks @Niteshooter for the bug report): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/cd7fcdbf54b4433f245647a521a36b05b930a5ac
- Fix VFO frequency input final digit handling: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/3d4ffd7900eab5bc18e53fc7db93266267ffa8e8
- Bug fixes: Receiving the same channel in Dual Watch mode, disabling channel exclusion, changing the scan list, compilation error: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/5b638e298efa3264b218c3f15890d63929689663
```No changes regarding channel exclusion and compilation errors```

- UI improvements, backlight toggle in FM radio, code optimization: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/793a44855d7dd3366683b78ae3ba2588e3a01552
- Added backlight fading, improved backlight control in spectrum: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/5d88fda158515967c420d77c95308dfc99509c56
```No backlight fading, just an improvement to the backlight in Spectrum```

- Fix spectrum visualisation for edge cases: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/2f01dd0118edb6c7f23e76d12c1a8e9ceb960145
- Fix spectrum range: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/1e33ff0f1b3fa147ae9274dd7c2a8eff292bff5b
- App: clean up duplicate ARRAY_SIZE macros: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/7189d09d73ed18977437c2f5d6569a73be2981aa
- Minor cleanups and adjustments related to these changes: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/e5ca2265e43ca1d7c17b1758f0ae062a62a5bc23
```Only changes related to AirCopy```

- Revert welcome.c and fix default keepAlive to 3 (PR armel#218): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/e77e558d646bbeea04feaf78c09d26e76364dbf7
- Increase the keepAlive value, fix the CHIRP connection while maintaining the fix for the button getting stuck: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/f4d8abd7d93a12098c131e58034d1ef5869dd30a
```The only change is to the keepAlive value```

- Minor code refactoring (24 B): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/85dae05ad390b90c66b0c994b8ded0a8e79db968
- Improve SMeter Calibration: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/4937d0baba5ed548a952f3ab4602cb27603488b7
- Fix for S-meter calculation, AirCopy - removed redundant code: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/138e078984da01f204e97a44f9a20f0a8fa5326a
- Fix TXLock icon: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/e555b488113b3c156a99a76dec411849a2d51cd0
- Add more scanlist: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/dccdd374640f130c1464e534dc6857d216b1623b
```I just added “gScanStateDir != SCAN_OFF”```

- Remove stars…: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/6b4e575d1f8d1beaeefab4e68b2d37c0d63b88f2
- Overlap between Live DTMF and Unlock Keyboard (issue armel# 215): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/5cb6bbdf7a5588ad0fc53768480cea0e3cda6823
- Displaying power bars during TX when using SetPwr: https://github.com/armel/uv-k1-k5v3-firmware-custom/pull/232/changes/f4a32b4350589de7fac846c92afe71cc520b4eba
- Code optimization (32 B); Restore full VFO state on long press of EXIT: https://github.com/armel/uv-k1-k5v3-firmware-custom/pull/232/changes/aa69d698a77d78f95a7f382bf1fe8e28076d8540
- Improvements to the FM radio and side buttons: https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/bbbc55306455cbddd783fffa4db818434a1963a0
```Just refactoring and fixing the crackling during beeps on the FM radio```
- Code refactoring (64 B): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/25b96be1a32b692f9b498ea46d3b18d647f44b89
- Code refactoring (136 B): https://github.com/armel/uv-k1-k5v3-firmware-custom/commit/c5da503cb374d51b53a58763ff27ab1ae4cde1e6

---

I carried over a lot of features from version V3, although I had to leave out things like backlight fading and button input from K5Viewer (the code was too large). As for the Basic version - check this out:

<img width="937" height="379" alt="image" src="https://github.com/user-attachments/assets/05ee5177-bf16-43f5-ba4b-310d1fc3d984" />


I'm looking forward to hearing your thoughts. I'm curious to see how these changes will work out.

---

```
📺 Compiling Bandscope...
   text    data     bss     dec     hex filename
  60932      52    6676   67660   1084c f4hwn.bandscope
📻 Compiling Broadcast...
   text    data     bss     dec     hex filename
  60244      20    6304   66568   10408 f4hwn.broadcast
☘️ Compiling Basic...
   text    data     bss     dec     hex filename
  61372      52    3420   64844    fd4c f4hwn.basic
🚨 Compiling RescueOps...
   text    data     bss     dec     hex filename
  57728      20    6256   64004    fa04 f4hwn.rescueops
🎮 Compiling Game...
   text    data     bss     dec     hex filename
  61124      32    3240   64396    fb8c f4hwn.game
  ```