### PR TITLE
Validate EEPROM UART request lengths

### DIFF
--- a/app/uart.c
+++ b/app/uart.c
@@ -163,6 +163,7 @@ static union
 
 static uint32_t Timestamp;
 static uint16_t gUART_WriteIndex;
+static uint16_t UART_CommandSize;
 static bool     bIsEncrypted = true;
 
 static void SendReply(void *pReply, uint16_t Size)
@@ -262,6 +263,7 @@ static void CMD_051B(const uint8_t *pBuffer)
     const CMD_051B_t *pCmd = (const CMD_051B_t *)pBuffer;
     REPLY_051B_t      Reply;
     bool              bLocked = false;
+    uint8_t           size = pCmd->Size;
 
     if (pCmd->Timestamp != Timestamp)
         return;
@@ -272,19 +274,22 @@ static void CMD_051B(const uint8_t *pBuffer)
         gFmRadioCountdown_500ms = fm_radio_countdown_500ms;
     #endif
 
+    if (size > sizeof(Reply.Data.Data))
+        size = sizeof(Reply.Data.Data);
+
     memset(&Reply, 0, sizeof(Reply));
     Reply.Header.ID   = 0x051C;
-    Reply.Header.Size = pCmd->Size + 4;
+    Reply.Header.Size = size + 4;
     Reply.Data.Offset = pCmd->Offset;
-    Reply.Data.Size   = pCmd->Size;
+    Reply.Data.Size   = size;
 
     if (bHasCustomAesKey)
         bLocked = gIsLocked;
 
     if (!bLocked)
-        EEPROM_ReadBuffer(pCmd->Offset, Reply.Data.Data, pCmd->Size);
+        EEPROM_ReadBuffer(pCmd->Offset, Reply.Data.Data, size);
 
-    SendReply(&Reply, pCmd->Size + 8);
+    SendReply(&Reply, size + 8);
 }
 
 // write eeprom
@@ -493,6 +498,8 @@ bool UART_IsCommandAvailable(void)
     uint16_t CommandLength;
     uint16_t DmaLength = DMA_CH0->ST & 0xFFFU;
 
+    UART_CommandSize = 0;
+
     while (1)
     {
         if (gUART_WriteIndex == DmaLength)
@@ -574,7 +581,11 @@ bool UART_IsCommandAvailable(void)
     
     CRC = UART_Command.Buffer[Size] | (UART_Command.Buffer[Size + 1] << 8);
 
-    return (CRC_Calculate(UART_Command.Buffer, Size) != CRC) ? false : true;
+    if (CRC_Calculate(UART_Command.Buffer, Size) != CRC)
+        return false;
+
+    UART_CommandSize = Size;
+    return true;
 }
 
 void UART_HandleCommand(void)
@@ -582,16 +593,22 @@ void UART_HandleCommand(void)
     switch (UART_Command.Header.ID)
     {
         case 0x0514:
-            CMD_0514(UART_Command.Buffer);
+            if (UART_CommandSize >= sizeof(CMD_0514_t))
+                CMD_0514(UART_Command.Buffer);
             break;
     
         case 0x051B:
-            CMD_051B(UART_Command.Buffer);
+            if (UART_CommandSize >= sizeof(CMD_051B_t))
+                CMD_051B(UART_Command.Buffer);
             break;
     
-        case 0x051D:
-            CMD_051D(UART_Command.Buffer);
+        case 0x051D: {
+            const CMD_051D_t *pCmd = (const CMD_051D_t *)UART_Command.Buffer;
+            if (UART_CommandSize >= sizeof(*pCmd) &&
+                pCmd->Size <= UART_CommandSize - sizeof(*pCmd))
+                CMD_051D(UART_Command.Buffer);
             break;
+        }
     
         case 0x051F:    // Not implementing non-authentic command
             break;


### PR DESCRIPTION
The EEPROM UART handlers currently trust inner lengths that are not tied back to the CRC-validated outer payload. A short `0x051D` request can therefore claim data that was never received, while an oversized `0x051B` request can exceed the 128-byte reply buffer.

This change:

- retains the validated outer payload length and clears it before each parse;
- rejects undersized fixed commands and `0x051D` claims that extend beyond the received payload; and
- clamps `0x051B` EEPROM reads, reply metadata and reply length to the actual 128-byte buffer.

Valid wire behaviour is preserved. Writes retain the existing `size / 8` block behaviour, including the official v4.3 CHIRP driver's final 14-byte calibration slice at `0x1ff2`: it still writes one eight-byte block and returns the same acknowledgement.

Validation against current `main` (`fbcf26d8e9811b135b7e2d97bdefebaa4b3ed9e0`):

- compiled the production parser, dispatcher and handlers into an ASan/UBSan harness;
- exercised all 63,744 outer/claimed-length pairs (`249 * 256`) through encrypted framed dispatch;
- verified malformed write claims produce no simulated EEPROM writes or UART replies;
- checked every `0x051B` read size from 0 through 255, including byte-for-byte reply framing;
- covered valid writes, the 14-byte CHIRP tail, bad CRC/footer, truncated frames, stale parser state and timestamp rejection; and
- built all five v4.3 editions with ARM GCC 15.1 and warnings as errors.

| Edition | Raw bytes | Flash headroom |
|---|---:|---:|
| Bandscope | 61,248 | 192 |
| Basic | 61,224 | 216 |
| Broadcast | 60,232 | 1,208 |
| Game | 61,428 | 12 |
| RescueOps | 57,680 | 3,760 |

The combined hardened Basic candidate was also flashed and booted on a UV-K5. The official v4.3 CHIRP driver completed a guarded download-only read through the `0x051B` path, and independent pre/post EEPROM snapshots were byte-identical. No CHIRP upload or malformed frame was sent to the device, so the `0x051D` and adversarial-length evidence remains the exhaustive sanitised host harness above.

This change is limited to received-payload and reply-buffer lengths. EEPROM address-range validation is separate and is not claimed here.
