### PR TITLE
Bound big-font rendering and terminate EEPROM welcome buffers

### DIFF
--- a/ui/helper.c
+++ b/ui/helper.c
@@ -78,22 +78,39 @@ void UI_PrintStringBuffer(const char *pString, uint8_t * buffer, uint32_t char_w
     }
 }
 
+__attribute__((noinline))
 void UI_PrintString(const char *pString, uint8_t Start, uint8_t End, uint8_t Line, uint8_t Width)
 {
-    size_t i;
-    size_t Length = strlen(pString);
+    const size_t GlyphWidth = sizeof(gFontBig[0]) / 2;
+    size_t Available;
+    size_t Used;
+    size_t Length = 0;
+
+    if (Line >= FRAME_LINES - 1 || Width < GlyphWidth || Start > LCD_WIDTH - GlyphWidth)
+        return;
+
+    if (End > Start && End < LCD_WIDTH)
+        Available = (size_t)End - Start + 1;
+    else
+        Available = LCD_WIDTH - Start;
+
+    Used = (End > Start) ? Width : GlyphWidth;
+    while (Used <= Available && pString[Length] != '\0') {
+        Length++;
+        Used += Width;
+    }
 
     if (End > Start)
-        Start += (((End - Start) - (Length * Width)) + 1) / 2;
+        Start += (Available - (Used - Width)) / 2;
 
-    for (i = 0; i < Length; i++)
+    for (size_t i = 0; i < Length; i++)
     {
         const unsigned int ofs   = (unsigned int)Start + (i * Width);
         if (pString[i] > ' ' && pString[i] < 127)
         {
             const unsigned int index = pString[i] - ' ' - 1;
-            memcpy(gFrameBuffer[Line + 0] + ofs, &gFontBig[index][0], 7);
-            memcpy(gFrameBuffer[Line + 1] + ofs, &gFontBig[index][7], 7);
+            memcpy(gFrameBuffer[Line + 0] + ofs, &gFontBig[index][0], GlyphWidth);
+            memcpy(gFrameBuffer[Line + 1] + ofs, &gFontBig[index][GlyphWidth], GlyphWidth);
         }
     }
 }

--- a/ui/welcome.c
+++ b/ui/welcome.c
@@ -49,8 +49,8 @@ void UI_DisplayReleaseKeys(void)
 
 void UI_DisplayWelcome(void)
 {
-    char WelcomeString0[16];
-    char WelcomeString1[16];
+    char WelcomeString0[17];
+    char WelcomeString1[17];
     char WelcomeString2[16];
     char WelcomeString3[20];
 


### PR DESCRIPTION
`UI_PrintString` currently scans without a bound and writes each glyph without checking the framebuffer geometry. The two 16-byte EEPROM welcome fields are also not guaranteed to contain a terminator. A terminated 15-character input reproduces out-of-bounds framebuffer access in the v4.3 renderer under UBSan.

This change:

- gives the buffer for each 16-byte EEPROM welcome field a dedicated terminator byte;
- bounds the big-font scan by the number of glyphs that physically fit;
- validates the two framebuffer rows, start column and glyph stride; and
- uses the actual font glyph width for copies.

The function is kept out of line because v4.3's LTO otherwise creates a larger split implementation. This is a normal UI rendering path, not an ISR or radio timing path.

Validation performed against v4.3 commit `fbcf26d8e9811b135b7e2d97bdefebaa4b3ed9e0`:

- the original 15-character case reproduces the UBSan failure and the fixed renderer passes under ASan/UBSan;
- golden framebuffer checks show byte-for-byte identical output for existing safe welcome, release, menu, FM and unlock strings;
- unterminated 15/16-byte inputs and invalid line/start/width regions are bounded;
- all 16,777,216 combinations of uint8 start/end/width geometry were modelled within the 128-column rows; and
- all five v4.3 editions built with GCC 15.1 and warnings as errors.

| Edition | Raw bytes | Flash headroom |
|---|---:|---:|
| Bandscope | 61,256 | 184 |
| Basic | 61,244 | 196 |
| Broadcast | 59,976 | 1,464 |
| Game | 61,400 | 40 |
| RescueOps | 57,680 | 3,760 |

This patch is deliberately limited to `UI_PrintString` and the EEPROM welcome fields; the small-font/buffer helpers are unchanged.

The combined hardened Basic candidate was flashed and booted on a UV-K5; existing welcome/main/menu/spectrum screens rendered and navigated without a visible fault. Maximum/unterminated EEPROM strings were not written to the device, so the actual boundary proof remains the golden sanitiser and exhaustive geometry tests above.