### PR TITLE
Fix memory-safety and correctness bugs found in code audit

### DIFF
--- a/app/breakout.c
+++ b/app/breakout.c
@@ -460,7 +460,7 @@ void APP_RunBreakout(void) {
         static uint8_t swap = 0;
 
         // Init seed
-        srand_custom(BK4819_ReadRegister(BK4819_REG_67) & 0x01FF * gBatteryVoltageAverage * gEeprom.VfoInfo[0].pRX->Frequency);
+        srand_custom((BK4819_ReadRegister(BK4819_REG_67) & 0x01FF) * gBatteryVoltageAverage * gEeprom.VfoInfo[0].pRX->Frequency);
 
         // Init led
         BK4819_ToggleGpioOut(BK4819_GPIO6_PIN2_GREEN, false);

--- a/app/dtmf.c
+++ b/app/dtmf.c
@@ -116,20 +116,27 @@ bool DTMF_ValidateCodes(char *pCode, const unsigned int size)
 {
     unsigned int i;
 
+    if (size == 0)
+        return false;
+
     if (pCode[0] == 0xFF || pCode[0] == 0)
         return false;
 
-    for (i = 0; i < size; i++)
+    // Reserve the last byte for a guaranteed NUL terminator: downstream code
+    // (sprintf "%s", strlen(), BK4819_PlayDTMFString's raw pString[i] loop)
+    // treats this field as a plain C string with no length bound, so a code
+    // that fills every byte with valid DTMF characters must not be accepted
+    // as-is or those readers run off the end of the field.
+    for (i = 0; i < size - 1; i++)
     {
         if (pCode[i] == 0xFF || pCode[i] == 0)
-        {
-            pCode[i] = 0;
             break;
-        }
 
         if ((pCode[i] < '0' || pCode[i] > '9') && (pCode[i] < 'A' || pCode[i] > 'D') && pCode[i] != '*' && pCode[i] != '#')
             return false;
     }
+
+    pCode[i] = 0;
 
     return true;
 }

--- a/app/uart.c
+++ b/app/uart.c
@@ -14,6 +14,7 @@
  *     limitations under the License.
  */
 
+#include <stddef.h>
 #include <string.h>
 
 #if !defined(ENABLE_OVERLAY)
@@ -262,6 +263,9 @@ static void CMD_051B(const uint8_t *pBuffer)
     const CMD_051B_t *pCmd = (const CMD_051B_t *)pBuffer;
     REPLY_051B_t      Reply;
     bool              bLocked = false;
+    // pCmd->Size comes straight off the wire (0-255); clamp it to the reply
+    // buffer's real capacity or EEPROM_ReadBuffer() overflows Reply's stack storage.
+    const uint8_t     Size = (pCmd->Size <= sizeof(Reply.Data.Data)) ? pCmd->Size : sizeof(Reply.Data.Data);
 
     if (pCmd->Timestamp != Timestamp)
         return;
@@ -274,17 +278,17 @@ static void CMD_051B(const uint8_t *pBuffer)
 
     memset(&Reply, 0, sizeof(Reply));
     Reply.Header.ID   = 0x051C;
-    Reply.Header.Size = pCmd->Size + 4;
+    Reply.Header.Size = Size + 4;
     Reply.Data.Offset = pCmd->Offset;
-    Reply.Data.Size   = pCmd->Size;
+    Reply.Data.Size   = Size;
 
     if (bHasCustomAesKey)
         bLocked = gIsLocked;
 
     if (!bLocked)
-        EEPROM_ReadBuffer(pCmd->Offset, Reply.Data.Data, pCmd->Size);
+        EEPROM_ReadBuffer(pCmd->Offset, Reply.Data.Data, Size);
 
-    SendReply(&Reply, pCmd->Size + 8);
+    SendReply(&Reply, Size + 8);
 }
 
 // write eeprom
@@ -314,8 +318,12 @@ static void CMD_051D(const uint8_t *pBuffer)
 
     if (!bIsLocked)
     {
+        // pCmd->Size comes straight off the wire (0-255); clamp it so
+        // pCmd->Data[] never reads past UART_Command.Buffer's real storage.
+        const uint8_t MaxSize = sizeof(UART_Command.Buffer) - offsetof(CMD_051D_t, Data);
+        const uint8_t Size    = (pCmd->Size <= MaxSize) ? pCmd->Size : MaxSize;
         unsigned int i;
-        for (i = 0; i < (pCmd->Size / 8); i++)
+        for (i = 0; i < (Size / 8); i++)
         {
             const uint16_t Offset = pCmd->Offset + (i * 8U);
 

--- a/driver/i2c.c
+++ b/driver/i2c.c
@@ -137,6 +137,9 @@ int I2C_ReadBuffer(void *pBuffer, uint8_t Size)
     uint8_t *pData = (uint8_t *)pBuffer;
     uint8_t i;
 
+    if (Size == 0)
+        return 0;
+
     for (i = 0; i < Size - 1; i++) {
         SYSTICK_DelayUs(1);
         pData[i] = I2C_Read(false);

--- a/driver/st7565.c
+++ b/driver/st7565.c
@@ -28,13 +28,16 @@
 uint8_t gStatusLine[LCD_WIDTH];
 uint8_t gFrameBuffer[FRAME_LINES][LCD_WIDTH];
 
-static void DrawLine(uint8_t column, uint8_t line, const uint8_t * lineBuffer, unsigned size_defVal)
-{   
+// When lineBuffer is NULL, every byte sent is fillValue instead; size is
+// always the number of bytes to transmit (never conflate it with the fill
+// value - see history of this function for the regression that did).
+static void DrawLine(uint8_t column, uint8_t line, const uint8_t * lineBuffer, uint8_t fillValue, unsigned size)
+{
     ST7565_SelectColumnAndLine(column + 4, line);
     GPIO_SetBit(&GPIOB->DATA, GPIOB_PIN_ST7565_A0);
-    for (unsigned i = 0; i < size_defVal; i++) {
+    for (unsigned i = 0; i < size; i++) {
         while ((SPI0->FIFOST & SPI_FIFOST_TFF_MASK) != SPI_FIFOST_TFF_BITS_NOT_FULL) {}
-        SPI0->WDR = lineBuffer ? lineBuffer[i] : size_defVal;
+        SPI0->WDR = lineBuffer ? lineBuffer[i] : fillValue;
     }
     SPI_WaitForUndocumentedTxFifoStatusBit();
 }
@@ -42,7 +45,7 @@ static void DrawLine(uint8_t column, uint8_t line, const uint8_t * lineBuffer, u
 void ST7565_DrawLine(const unsigned int Column, const unsigned int Line, const uint8_t *pBitmap, const unsigned int Size)
 {
     SPI_ToggleMasterMode(&SPI0->CR, false);
-    DrawLine(Column, Line, pBitmap, Size);
+    DrawLine(Column, Line, pBitmap, 0, Size);
     SPI_ToggleMasterMode(&SPI0->CR, true);
 }
 
@@ -62,16 +65,16 @@ void ST7565_DrawLine(const unsigned int Column, const unsigned int Line, const u
 
         if(line == 0)
         {
-            DrawLine(0, 0, gStatusLine, LCD_WIDTH);
+            DrawLine(0, 0, gStatusLine, 0, LCD_WIDTH);
         }
         else if(line <= FRAME_LINES)
         {
-            DrawLine(0, line, gFrameBuffer[line - 1], LCD_WIDTH);
+            DrawLine(0, line, gFrameBuffer[line - 1], 0, LCD_WIDTH);
         }
         else
         {
             for (line = 1; line <= FRAME_LINES; line++) {
-                DrawLine(0, line, gFrameBuffer[line - 1], LCD_WIDTH);
+                DrawLine(0, line, gFrameBuffer[line - 1], 0, LCD_WIDTH);
             }
         }
 
@@ -98,7 +101,7 @@ void ST7565_DrawLine(const unsigned int Column, const unsigned int Line, const u
         SPI_ToggleMasterMode(&SPI0->CR, false);
         ST7565_WriteByte(0x40);
         for (unsigned line = 0; line < FRAME_LINES; line++) {
-            DrawLine(0, line+1, gFrameBuffer[line], LCD_WIDTH);
+            DrawLine(0, line+1, gFrameBuffer[line], 0, LCD_WIDTH);
         }
         SPI_ToggleMasterMode(&SPI0->CR, true);
     }
@@ -107,7 +110,7 @@ void ST7565_DrawLine(const unsigned int Column, const unsigned int Line, const u
     {
         SPI_ToggleMasterMode(&SPI0->CR, false);
         ST7565_WriteByte(0x40);    // start line ?
-        DrawLine(0, line+1, gFrameBuffer[line], LCD_WIDTH);
+        DrawLine(0, line+1, gFrameBuffer[line], 0, LCD_WIDTH);
         SPI_ToggleMasterMode(&SPI0->CR, true);
     }
 
@@ -115,7 +118,7 @@ void ST7565_DrawLine(const unsigned int Column, const unsigned int Line, const u
     {   // the top small text line on the display
         SPI_ToggleMasterMode(&SPI0->CR, false);
         ST7565_WriteByte(0x40);    // start line ?
-        DrawLine(0, 0, gStatusLine, LCD_WIDTH);
+        DrawLine(0, 0, gStatusLine, 0, LCD_WIDTH);
         SPI_ToggleMasterMode(&SPI0->CR, true);
     }
 #endif
@@ -124,7 +127,7 @@ void ST7565_FillScreen(uint8_t value)
 {
     SPI_ToggleMasterMode(&SPI0->CR, false);
     for (unsigned i = 0; i < 8; i++) {
-        DrawLine(0, i, NULL, value);
+        DrawLine(0, i, NULL, value, LCD_WIDTH);
     }
     SPI_ToggleMasterMode(&SPI0->CR, true);
 }
@@ -219,6 +222,8 @@ uint8_t cmds[] = {
         {
             ST7565_Cmd(i);
         }
+        SPI_WaitForUndocumentedTxFifoStatusBit();
+        SPI_ToggleMasterMode(&SPI0->CR, true);
     }
     #endif
 

--- a/main.c
+++ b/main.c
@@ -164,18 +164,10 @@ void Main(void)
         #ifdef ENABLE_FEAT_F4HWN
             gEeprom.KEY_LOCK = 0;
             SETTINGS_SaveSettings();
-            #ifndef ENABLE_VOX
-                gMenuCursor = 67; // move to hidden section, fix me if change... !!! Remove VOX and Mic Bar
-            #else
-                gMenuCursor = 68; // move to hidden section, fix me if change... !!!
-            #endif
-
-            #ifdef ENABLE_NOAA
-                gMenuCursor += 1; // move to hidden section, fix me if change... !!!
-            #endif
-            #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
-                gMenuCursor += 1; // move to hidden section, fix me if change... !!!
-            #endif
+            // Look MENU_F_LOCK's position up in MenuList[] directly instead of
+            // hardcoding its index: that index silently goes stale whenever any
+            // build flag that adds/removes a menu entry before F Lock changes.
+            gMenuCursor = UI_MENU_GetMenuIdx(MENU_F_LOCK);
             gSubMenuSelection = gSetting_F_LOCK;
         #endif
     }

--- a/radio.c
+++ b/radio.c
@@ -104,8 +104,14 @@ bool RADIO_CheckValidChannel(uint16_t channel, bool checkScanList, uint8_t scanL
 
     //return true;
 
-    // I don't understand what this code is for...
-    
+    // SCANLIST_PRIORITY_CH1/2 only have entries for the 3 numbered scan
+    // lists (index scanList-1, valid for scanList 1..3). scanList==0 ("not
+    // in any list") and scanList==4 ("in any list") have no corresponding
+    // priority-channel pair, so scanList-1 would index out of bounds
+    // (-1, or 3 on a 3-entry array) - skip the priority check for those.
+    if (scanList < 1 || scanList > 3)
+        return true;
+
     const uint8_t PriorityCh1 = gEeprom.SCANLIST_PRIORITY_CH1[scanList - 1];
     const uint8_t PriorityCh2 = gEeprom.SCANLIST_PRIORITY_CH2[scanList - 1];
 
@@ -395,7 +401,10 @@ void RADIO_ConfigureChannel(const unsigned int VFO, const unsigned int configure
 
     pVfo->freq_config_RX.Frequency = frequency;
 
-    if (frequency >= frequencyBandTable[BAND2_108MHz].upper && frequency < frequencyBandTable[BAND2_108MHz].upper)
+    // was ".upper && < .upper" (always false, dead code) - should bound the
+    // whole BAND2_108MHz (receive-only airband) range, matching the
+    // ">= lower && < upper" convention used elsewhere in this file.
+    if (frequency >= frequencyBandTable[BAND2_108MHz].lower && frequency < frequencyBandTable[BAND2_108MHz].upper)
         pVfo->TX_OFFSET_FREQUENCY_DIRECTION = TX_OFFSET_FREQUENCY_DIRECTION_OFF;
     else if (!IS_MR_CHANNEL(channel))
         pVfo->TX_OFFSET_FREQUENCY = FREQUENCY_RoundToStep(pVfo->TX_OFFSET_FREQUENCY, pVfo->StepFrequency);

--- a/settings.c
+++ b/settings.c
@@ -911,9 +911,12 @@ void SETTINGS_SaveChannelName(uint8_t channel, const char * name)
 
 void SETTINGS_UpdateChannel(uint8_t channel, const VFO_Info_t *pVFO, bool keep, bool check, bool save)
 {
-#ifdef ENABLE_NOAA
-    if (!IS_NOAA_CHANNEL(channel))
-#endif
+    // gMR_ChannelAttributes[] only has FREQ_CHANNEL_LAST+1 (207) entries, covering
+    // MR+FREQ channels; NOAA channels (207..216) and anything beyond are handled
+    // elsewhere. This bound must stay unconditional and independent of ENABLE_NOAA,
+    // or an out-of-range channel value (this is a uint8_t, so up to 255) would
+    // write past the array.
+    if (channel <= FREQ_CHANNEL_LAST)
     {
         uint8_t  state[8];
         ChannelAttributes_t  att = {

--- a/ui/aircopy.c
+++ b/ui/aircopy.c
@@ -27,11 +27,21 @@
 #include "ui/helper.h"
 #include "ui/inputbox.h"
 
+// crc[] (misc.c) is a fixed uint8_t[15] = 120 bits. gErrorsDuringAirCopy grows
+// independently of gAirCopyBlockNumber (it increments on every CRC error, with
+// no combined cap), so bit_index can exceed 120 - bound it here rather than at
+// every call site.
+#define CRC_BIT_COUNT 120
+
 static void set_bit(uint8_t* array, int bit_index) {
+    if (bit_index < 0 || bit_index >= CRC_BIT_COUNT)
+        return;
     array[bit_index / 8] |= (1 << (bit_index % 8));
 }
 
 static int get_bit(uint8_t* array, int bit_index) {
+    if (bit_index < 0 || bit_index >= CRC_BIT_COUNT)
+        return 0;
     return (array[bit_index / 8] >> (bit_index % 8)) & 1;
 }
 
@@ -104,7 +114,10 @@ void UI_DisplayAircopy(void)
             lErrorsDuringAirCopy = gErrorsDuringAirCopy;
         }
 
-        for(uint8_t i = 0; i < (gAirCopyBlockNumber + gErrorsDuringAirCopy); i++)
+        // i is widened to uint16_t and capped at CRC_BIT_COUNT: with an unbounded
+        // gErrorsDuringAirCopy, a uint8_t loop variable could wrap and spin forever,
+        // and i+4 must stay within gFrameBuffer[4]'s 128-byte row.
+        for(uint16_t i = 0; i < (gAirCopyBlockNumber + gErrorsDuringAirCopy) && i < CRC_BIT_COUNT; i++)
         {
             if(get_bit(crc, i) == 0)
             {

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -950,7 +950,7 @@ void UI_DisplayMenu(void)
 
 #ifdef ENABLE_DTMF_CALLING
         case MENU_ANI_ID:
-            strcpy(String, gEeprom.ANI_DTMF_ID);
+            sprintf(String, "%.8s", gEeprom.ANI_DTMF_ID);
             break;
 #endif
         case MENU_UPCODE:
@@ -1262,7 +1262,10 @@ void UI_DisplayMenu(void)
 
         char *pPrintStr = String;
 
-        if (gSubMenuSelection < 0) {
+        // RADIO_FindNextChannel() returns 0xFF ("not found") into this
+        // int32_t, which is never < 0 - IS_MR_CHANNEL() catches both that
+        // sentinel and any genuinely negative value.
+        if (!IS_MR_CHANNEL(gSubMenuSelection)) {
             pPrintStr = "NULL";
         } else {
             UI_GenerateChannelStringEx(String, true, gSubMenuSelection);
@@ -1276,7 +1279,7 @@ void UI_DisplayMenu(void)
         pPrintStr = String[0] ? String : "--";
 
         // channel name and scan-list
-        if (gSubMenuSelection < 0 || !gEeprom.SCAN_LIST_ENABLED[i]) {
+        if (!IS_MR_CHANNEL(gSubMenuSelection) || !gEeprom.SCAN_LIST_ENABLED[i]) {
             UI_PrintString(pPrintStr, menu_item_x1, menu_item_x2, 2, 8);
         } else {
             /*

--- a/ui/welcome.c
+++ b/ui/welcome.c
@@ -77,6 +77,12 @@ void UI_DisplayWelcome(void)
 
         EEPROM_ReadBuffer(0x0EB0, WelcomeString0, 16);
         EEPROM_ReadBuffer(0x0EC0, WelcomeString1, 16);
+        // Guarantee NUL termination: a radio whose welcome-string EEPROM range
+        // was never programmed by CHIRP/vendor tools can hold 16 bytes with no
+        // terminator, and strlen()/UI_PrintString() below would then run past
+        // these 16-byte stack buffers looking for one.
+        WelcomeString0[sizeof(WelcomeString0) - 1] = 0;
+        WelcomeString1[sizeof(WelcomeString1) - 1] = 0;
 
         sprintf(WelcomeString2, "%u.%02uV %u%%",
                 gBatteryVoltageAverage / 100,


### PR DESCRIPTION
- app/uart.c: clamp attacker-controlled Size fields in the UART EEPROM read (CMD_051B) and write (CMD_051D) commands to their real buffer capacity, closing a stack buffer overflow and an out-of-bounds read.
- app/dtmf.c: DTMF_ValidateCodes() now always guarantees NUL termination, fixing overflows in downstream sprintf/strcpy/ BK4819_PlayDTMFString consumers when a code fills its field with no terminator.
- ui/welcome.c: force-terminate the welcome-message strings read raw from EEPROM, which could otherwise be unterminated on a radio never programmed via CHIRP and overrun the framebuffer.
- driver/st7565.c: fix DrawLine()/FillScreen() conflating the SPI byte-count and fill-value parameters (a prior refactor regression), which left the display never actually clearing; also fixed ST7565_ContrastAndInv() leaving SPI master mode toggled off.
- radio.c: fix an out-of-bounds SCANLIST_PRIORITY_CH array access in RADIO_CheckValidChannel() for scanList 0 and 4, and a dead/always-false BAND2_108MHz bounds check that silently disabled the TX-offset-off rule for the receive-only airband.
- ui/menu.c: fix the scan-list "NULL" placeholder never triggering because the not-found sentinel (0xFF) doesn't satisfy a `< 0` check on an int32_t.
- settings.c: keep SETTINGS_UpdateChannel's channel bounds check active regardless of ENABLE_NOAA, preventing an out-of-bounds array write.
- ui/aircopy.c: bound the CRC bitset helpers and display loop against the fixed-size crc[] array instead of an unbounded error counter.
- app/breakout.c: fix an operator-precedence bug in the game's RNG seed.
- driver/i2c.c: fix I2C_ReadBuffer() writing a stray byte on Size == 0.
- main.c: replace the hardcoded, comment-flagged-as-fragile boot-menu cursor index with a lookup via the existing UI_MENU_GetMenuIdx() helper, so it can't silently go stale when menu-affecting build flags change.

Verified via Docker build (arm-none-eabi toolchain) across Custom, RescueOps (NOAA+Aircopy), Bandscope (Aircopy, no VOX), and ENABLE_DTMF_CALLING=1 configurations - all compile clean with -Werror.