### PR TITLE
Fix 3 compile bugs that only surface under specific ENABLE_ flag combinations

### DIFF
--- a/app/action.c
+++ b/app/action.c
@@ -242,6 +242,7 @@ void ACTION_Scan(bool bRestart)
         gScheduleScanListen    = false;
     } else {
         #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
+        #ifdef ENABLE_SCAN_RANGES
         if(gScanRangeStart == 0) // No ScanRange
         {
             gEeprom.CURRENT_STATE = 1;
@@ -250,6 +251,9 @@ void ACTION_Scan(bool bRestart)
         {
             gEeprom.CURRENT_STATE = 2;
         }
+        #else
+        gEeprom.CURRENT_STATE = 1; // ScanRange feature not built - always a plain scan
+        #endif
         SETTINGS_WriteCurrentState();
         #endif
         // start scanning

--- a/app/main.c
+++ b/app/main.c
@@ -344,9 +344,12 @@ void channelMove(uint16_t Channel)
 
     gBeepToPlay = BEEP_NONE;
 
-    #ifdef ENABLE_VOICE
-        gAnotherVoiceID        = (VOICE_ID_t)Key;
-    #endif
+    // ENABLE_VOICE used to announce a `Key` here that channelMove() never
+    // had in scope (a pre-existing bug - this never compiled under
+    // ENABLE_VOICE). Both real callers already announce the pressed digit
+    // themselves where a key press actually exists (MAIN_Key_DIGITS, right
+    // after calling channelMoveSwitch() -> channelMove()); the other caller
+    // is a countdown-timeout callback with no live keypress to announce.
 
     gEeprom.MrChannel[Vfo]     = (uint8_t)Channel;
     gEeprom.ScreenChannel[Vfo] = (uint8_t)Channel;

--- a/app/menu.c
+++ b/app/menu.c
@@ -1664,11 +1664,14 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 
     if (!gIsInSubMenu)
     {
-        #ifdef ENABLE_VOICE
-            if (UI_MENU_GetCurrentMenuId() != MENU_SCR)
-                gAnotherVoiceID = MenuList[gMenuCursor].voice_id;
-        #endif
-        if (UI_MENU_GetCurrentMenuId() == MENU_UPCODE 
+        // t_menu_item.voice_id (the source for this per-item announcement)
+        // was deliberately removed in "Save 116 bytes" to cut flash size;
+        // this ENABLE_VOICE-only call site was missed at the time and has
+        // been broken (both a stale `voice_id` member and a MENU_SCR that
+        // doesn't exist under ENABLE_FEAT_F4HWN) ever since. Not restoring
+        // the field since that would undo the size optimization for
+        // everyone - MENU no longer has a per-item voice announcement here.
+        if (UI_MENU_GetCurrentMenuId() == MENU_UPCODE
             || UI_MENU_GetCurrentMenuId() == MENU_DWCODE 
 #ifdef ENABLE_DTMF_CALLING 
             || UI_MENU_GetCurrentMenuId() == MENU_ANI_ID
@@ -1782,10 +1785,14 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
     SCANNER_Stop();
 
     #ifdef ENABLE_VOICE
-        if (UI_MENU_GetCurrentMenuId() == MENU_SCR)
-            gAnotherVoiceID = (gSubMenuSelection == 0) ? VOICE_ID_SCRAMBLER_OFF : VOICE_ID_SCRAMBLER_ON;
-        else
-            gAnotherVoiceID = VOICE_ID_CONFIRM;
+        // MENU_SCR (the scrambler menu) only exists when ENABLE_FEAT_F4HWN
+        // is off - it's a different, unified menu item under F4HWN.
+        #ifndef ENABLE_FEAT_F4HWN
+            if (UI_MENU_GetCurrentMenuId() == MENU_SCR)
+                gAnotherVoiceID = (gSubMenuSelection == 0) ? VOICE_ID_SCRAMBLER_OFF : VOICE_ID_SCRAMBLER_ON;
+            else
+        #endif
+                gAnotherVoiceID = VOICE_ID_CONFIRM;
     #endif
 
     gInputBoxIndex = 0;

--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -945,8 +945,8 @@ uint8_t Rssi2Y(uint16_t rssi)
         {
             uint16_t rssi = rssiHistory[(bars>128) ? i >> settings.stepsCount : i];
             
-#ifdef ENABLE_SCAN_RANGES
             uint8_t x;
+#ifdef ENABLE_SCAN_RANGES
             if (gScanRangeStart && bars > 1)
             {
                 // Total width units = (bars - 1) full bars + 2 half bars = bars
@@ -1779,8 +1779,9 @@ void APP_RunSpectrum()
             gEeprom.CURRENT_STATE = 5;
         #endif
     }
-    else {
+    else
 #endif
+    {
         currentFreq = initialFreq = gTxVfo->pRX->Frequency -
                                     ((GetStepsCount() / 2) * GetScanStep());
         #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE

--- a/main.c
+++ b/main.c
@@ -336,6 +336,7 @@ void Main(void)
     */
 
     #ifdef ENABLE_FEAT_F4HWN_RESUME_STATE
+        #ifdef ENABLE_SCAN_RANGES
         if (gEeprom.CURRENT_STATE == 2 || gEeprom.CURRENT_STATE == 5) {
             gScanRangeStart = gScanRangeStart ? 0 : gTxVfo->pRX->Frequency;
             gScanRangeStop = gEeprom.VfoInfo[!gEeprom.TX_VFO].freq_config_RX.Frequency;
@@ -343,6 +344,7 @@ void Main(void)
                 SWAP(gScanRangeStart, gScanRangeStop);
             }
         }
+        #endif
 
         if (gEeprom.CURRENT_STATE == 1) {
             gEeprom.SCAN_LIST_DEFAULT = gEeprom.CURRENT_LIST;

--- a/ui/main.c
+++ b/ui/main.c
@@ -878,6 +878,13 @@ void UI_DisplayMain(void)
             if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))
             {   // it's a channel
 
+                // Declared here (rather than nested inside the scanlist-bitmap
+                // block below) so it's still in scope for the compander-symbol
+                // check further down, which lives outside that block - and,
+                // when ENABLE_FEAT_F4HWN_RESCUE_OPS is on, outside the
+                // MENU_LOCK block too.
+                const ChannelAttributes_t att = gMR_ChannelAttributes[gEeprom.ScreenChannel[vfo_num]];
+
                 #ifdef ENABLE_FEAT_F4HWN_RESCUE_OPS
                     if(gEeprom.MENU_LOCK == false) {
                 #endif
@@ -887,8 +894,6 @@ void UI_DisplayMain(void)
                 if(gMR_ChannelExclude[gEeprom.ScreenChannel[vfo_num]] == false)
                 {
                     // show the scan list assigment symbols
-                    const ChannelAttributes_t att = gMR_ChannelAttributes[gEeprom.ScreenChannel[vfo_num]];
-
                     countList = att.scanlist1 + att.scanlist2 + att.scanlist3;
 
                     if(countList == 0)

--- a/ui/status.c
+++ b/ui/status.c
@@ -133,14 +133,12 @@ void UI_DisplayStatus()
         UI_PrintStringSmallBufferNormal(str, line + x + 1);
         x += 16;
     #else
-        #ifdef ENABLE_VOICE
-        // VOICE indicator
-        if (gEeprom.VOICE_PROMPT != VOICE_PROMPT_OFF){
-            memcpy(line + x, BITMAP_VoicePrompt, sizeof(BITMAP_VoicePrompt));
-            x1 = x + sizeof(BITMAP_VoicePrompt);
-        }
-        x += sizeof(BITMAP_VoicePrompt);
-        #endif
+        // A "VOICE indicator" status-bar icon used to live here, referencing
+        // BITMAP_VoicePrompt - a bitmap that was never actually defined
+        // anywhere in the codebase (predates this repo's initial commit).
+        // Voice-prompt audio playback itself is unaffected; this only ever
+        // controlled a status icon that could never have compiled under
+        // ENABLE_VOICE until now, so there was never a real icon to keep.
 
         if(!SCANNER_IsScanning()) {
         #ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER


### PR DESCRIPTION
## Summary

While measuring the flash-size cost of every `ENABLE_*` flag individually (toggling each one from its default and rebuilding to diff `.text`/`.data`), I hit three genuine compile failures. `make` stops at the first error, so each fix uncovered the next one further into the build - none of these are related to each other except by discovery order.

- **`ENABLE_VOICE=1`**: `app/main.c`'s `channelMove()` referenced a `Key` variable that's never in scope there (dead leftover code - its real callers already announce the pressed key themselves via `gAnotherVoiceID = (VOICE_ID_t)Key;` right after calling it). Fixing that surfaced two more broken spots reachable only under `ENABLE_VOICE`:
  - `app/menu.c` referenced `MenuList[gMenuCursor].voice_id`, a `t_menu_item` struct field that was deliberately removed in a "Save 116 bytes" commit - this one call site was never updated to match.
  - `ui/status.c` referenced `BITMAP_VoicePrompt`, a bitmap that (as far as I can tell from history) was never actually defined anywhere.
  
  I removed the dead references in all three rather than restoring the removed struct field (that would undo the earlier size optimization for everyone) or inventing bitmap art I can't verify on hardware.

- **`ENABLE_BIG_FREQ=0`**: `ui/main.c` declares `const ChannelAttributes_t att = ...` inside a nested `if` block, then uses `att.compander` afterward, outside that scope - only reachable when `ENABLE_BIG_FREQ` is off (the default build never hits it, since that whole branch is `#ifndef ENABLE_BIG_FREQ`). Hoisted the declaration up so it's in scope everywhere it's needed, including the `ENABLE_FEAT_F4HWN_RESCUE_OPS` variant of the surrounding braces.

- **`ENABLE_SCAN_RANGES=0`**: `app/action.c`'s `ACTION_Scan` had an unguarded `gScanRangeStart` reference (that symbol's declaration is itself behind `#ifdef ENABLE_SCAN_RANGES`). Fixing it surfaced a genuinely broken `#ifdef`/`#else`/`#endif` in `app/spectrum.c` that spans an `if`/`else` in a way that leaves a stray unmatched `}` when the flag is off - corrupting the rest of that function (that's what produces the bizarre "isInitialized has type int" cascading errors if you hit it directly). Also one more unguarded `gScanRangeStart` reference in `main.c`'s boot-state restoration code.

## Test plan
- [x] Default build (all flags at existing defaults): byte-for-byte identical `.text` size to before this change (52,960 bytes)
- [x] `ENABLE_VOICE=1` compiles clean
- [x] `ENABLE_BIG_FREQ=0` compiles clean
- [x] `ENABLE_SCAN_RANGES=0` compiles clean
- [x] All three together compile clean
- [ ] Not tested on real hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)